### PR TITLE
Rename ss ci to ci to accept dd ci data

### DIFF
--- a/controllers/api/v2/report.es
+++ b/controllers/api/v2/report.es
@@ -250,6 +250,13 @@ router.post('/api/report/v2/night_battle_ci', async (ctx, next) => {
   }
 })
 
+// Compat for legacy plugin's night battle ss ci reporter
+// which is now night battle ci reporter and has changed url to above
+router.post('/api/report/v2/night_battle_ss_ci', async (ctx, next) => {
+  ctx.status = 200
+  await next()
+})
+
 export default (app) => {
   app.use(router.routes())
 }

--- a/controllers/api/v2/report.es
+++ b/controllers/api/v2/report.es
@@ -16,7 +16,7 @@ const BattleAPI          = mongoose.model('BattleAPI')
 const NightContactRecord = mongoose.model('NightContactRecord')
 const AACIRecord         = mongoose.model('AACIRecord')
 const RecipeRecord       = mongoose.model('RecipeRecord')
-const NightBattleSSCI    = mongoose.model('NightBattleSSCI')
+const NightBattleCI      = mongoose.model('NightBattleCI')
 
 function parseInfo(ctx) {
   const info = JSON.parse(ctx.request.body.data)
@@ -236,10 +236,10 @@ router.post('/api/report/v2/remodel_recipe', async (ctx, next) => {
   }
 })
 
-router.post('/api/report/v2/night_battle_ss_ci', async (ctx, next) => {
+router.post('/api/report/v2/night_battle_ci', async (ctx, next) => {
   try {
     const info = parseInfo(ctx)
-    const record = new NightBattleSSCI(info)
+    const record = new NightBattleCI(info)
     await record.saveAsync()
     ctx.status = 200
     await next()

--- a/models/report/night-battle-ci.es
+++ b/models/report/night-battle-ci.es
@@ -1,8 +1,9 @@
 import mongoose from 'mongoose'
 
-const NightBattleSSCI = new mongoose.Schema({
+const NightBattleCI = new mongoose.Schema({
   shipId: Number,
   CI: String,
+  type: String,
   lv: Number,
   rawLuck: Number,
   pos: Number,
@@ -22,8 +23,8 @@ const NightBattleSSCI = new mongoose.Schema({
   origin: String,
 })
 
-NightBattleSSCI.virtual('date').get(() => {
+NightBattleCI.virtual('date').get(() => {
   this._id.getTimestamp()
 })
 
-mongoose.model('NightBattleSSCI', NightBattleSSCI)
+mongoose.model('NightBattleCI', NightBattleCI)


### PR DESCRIPTION
new field `type`added for indicating ship types

Previous night battle ss ci collection could not be directly transformed into this new collection