### PR TITLE
Add baseExp in DropShipRecord schema

### DIFF
--- a/models/report/drop-ship.es
+++ b/models/report/drop-ship.es
@@ -14,6 +14,7 @@ const DropShipRecord = new mongoose.Schema({
   enemyShips1: [Number],
   enemyShips2: [Number],
   enemyFormation: Number,
+  baseExp: Number,
   origin: String,
 })
 


### PR DESCRIPTION
Ship experience is now variable, so this field is required to properly generate enemy patterns. Should be `api_get_base_exp` from `battleresult` in the reporter.