### PR TITLE
feat: add map info endpoint

### DIFF
--- a/controllers/api/v2/report.es
+++ b/controllers/api/v2/report.es
@@ -18,6 +18,7 @@ const AACIRecord         = mongoose.model('AACIRecord')
 const RecipeRecord       = mongoose.model('RecipeRecord')
 const NightBattleCI      = mongoose.model('NightBattleCI')
 const ShipStat           = mongoose.model('ShipStat')
+const MapInfo            = mongoose.model('MapInfo')
 
 function parseInfo(ctx) {
   const info = JSON.parse(ctx.request.body.data)
@@ -262,6 +263,31 @@ router.post('/api/report/v2/ship_stat', async (ctx, next) => {
   try {
     const info = parseInfo(ctx)
     await ShipStat.updateAsync({ id: info.id, lv: info.lv }, info, { upsert: true })
+    ctx.status = 200
+    await next()
+  } catch (e) {
+    ctx.status = 500
+    await next()
+  }
+})
+
+router.post('/api/report/v2/map_info', async (ctx, next) => {
+  try {
+    const info = parseInfo(ctx)
+    const { mapId, mapLv, mapGaugeType, mapGaugeNum, teitokuLv, mapHP } = info
+    await MapInfo.updateAsync({
+      mapId,
+      mapLv,
+      mapGaugeType,
+      mapGaugeNum,
+      teitokuLv,
+      mapHP,
+    }, {
+      ...info,
+      $inc: { count: 1 },
+    }, {
+      upsert: true,
+    })
     ctx.status = 200
     await next()
   } catch (e) {

--- a/models/report/map-info.es
+++ b/models/report/map-info.es
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose'
+
+const MapInfo = new mongoose.Schema({
+  mapId: Number,
+  mapLv: Number,
+  mapGaugeType: Number,
+  mapGaugeNum: Number,
+  teitokuLv: Number,
+  mapHP: Number,
+  count: Number,
+})
+
+mongoose.model('MapInfo', MapInfo)


### PR DESCRIPTION
Currently using it for event map HP/TP, as it depends on map/gauge stage/player rank/selected difficulty ([for example](https://kancolle.wikia.com/wiki/Winter_2018_Event/Info/HP?action=render)).

~~Another use case can be storing event rewards.~~

Collection should be small as `update`/`upsert` is used, like `ShipStat`, except there is also `$inc` with `counter` (in case there are bad reports, so that existing data is not lost).