### PR TITLE
Some improvements for ShipStat collection

### DIFF
--- a/controllers/api/v2/report.es
+++ b/controllers/api/v2/report.es
@@ -261,8 +261,15 @@ router.post('/api/report/v2/night_battle_ss_ci', async (ctx, next) => {
 
 router.post('/api/report/v2/ship_stat', async (ctx, next) => {
   try {
-    const info = parseInfo(ctx)
-    await ShipStat.updateAsync({ id: info.id, lv: info.lv }, info, { upsert: true })
+    const { id, lv, los, los_max, asw, asw_max, evasion, evasion_max } = parseInfo(ctx)
+    const last_timestamp = +new Date()
+    await ShipStat.updateAsync({
+      id, lv, los, los_max, asw, asw_max, evasion, evasion_max,
+    }, {
+      id, lv, los, los_max, asw, asw_max, evasion, evasion_max, last_timestamp, $inc: { count: 1 },
+    }, {
+      upsert: true,
+    })
     ctx.status = 200
     await next()
   } catch (e) {

--- a/models/report/ship-stat.es
+++ b/models/report/ship-stat.es
@@ -9,7 +9,8 @@ const ShipStat = new mongoose.Schema({
   asw_max: Number,
   evasion: Number,
   evasion_max: Number,
-  origin: String,
+  last_timestamp: Number,
+  count: Number,
 })
 
 mongoose.model('ShipStat', ShipStat)


### PR DESCRIPTION
This should address cases when records for some ship forms don't converge to a single pair of lv1/lv99 values.

- `last_timestamp` can be used when devs update stats, to filter out old records (`_id` timestamp is the first timestamp, since `update` doesn't update it).
- `count` can be used to filter out unpopular records (e.g., bugs that can prevent from finding lv1/lv99 values).
- All reported fields are used as keys, so each record is a unique configuration/event (observed stats for a given ship at a given level) with information about first observation time, last observation time, and the total number of observations for that configuration.

To give some examples, current problems finding lv1/lv99 values:

- Non-convergent records, most likely bugs (like single conflicting record for Fusou from ~1 year ago, `count` can be useful) or updates (like Hiei from today's update, `last_timestamp` can be useful):

```
Fusou Kai Ni asw : poi: ?, wctf: 8/28
Hiei Kai Ni los : poi: ?, wctf: 16/52
Hiryuu Kai Ni evasion : poi: ?, wctf: 40/83
Kasumi Kai Ni B los : poi: ?, wctf: 15/56
Maikaze Kai asw : poi: ?, wctf: 27/72
Yamakaze Kai asw : poi: ?, wctf: 30/73
```

- Different from WCTF, timestamp info can be useful:

```
Asashimo asw : poi: 35/70, wctf: 35/64
Gotland asw : poi: 36/58, wctf: 35/58
Hamanami Kai asw : poi: 28/65, wctf: 29/65
Saratoga Kai los : poi: 48/80, wctf: 52/80
```

- Not enough data here (not addressed by this PR, should be fixed on the client side by submitting more reports from other endpoints):

```
Maruyu evasion : poi: 8~9/19, wctf: 9/19
Maruyu los : poi: 0~1/9, wctf: 1/9
```