### PR TITLE
Run deployment hooks with fnm Node version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 *.sh text eol=lf
 *.yaml text eol=lf
 *.yml text eol=lf
+.gitignore text eol=lf
 github-master-hook text eol=lf
 fnm-exec text eol=lf
 supervisior.conf text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+
+*.sh text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+github-master-hook text eol=lf
+fnm-exec text eol=lf
+supervisior.conf text eol=lf

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,3 +24,8 @@ jobs:
       - run: npm run lint
       - run: npm run type-check
       - run: npm test
+      - name: Validate deploy hooks
+        run: |
+          bash -n github-master-hook
+          bash -n fnm-exec
+          ! grep -Il $'\r' github-master-hook fnm-exec supervisior.conf

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+.fnm-bin/
+.fnm/
 
 public
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ build/Release
 node_modules
 .fnm-bin/
 .fnm/
+.deploy-state
 
 public
 

--- a/fnm-exec
+++ b/fnm-exec
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+if ! command -v fnm >/dev/null 2>&1; then
+  echo "fnm is required but was not found in PATH" >&2
+  exit 127
+fi
+
+cd /srv/poi
+eval "$(fnm env --shell bash)"
+fnm use --install-if-missing
+
+exec "$@"

--- a/fnm-exec
+++ b/fnm-exec
@@ -11,6 +11,6 @@ fi
 
 cd /srv/poi
 eval "$("$FNM_BIN" env --shell bash)"
-"$FNM_BIN" use --install-if-missing
+"$FNM_BIN" use
 
 exec "$@"

--- a/fnm-exec
+++ b/fnm-exec
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-export FNM_DIR="${FNM_DIR:-/home/poi/.local/share/fnm}"
-FNM_BIN="${FNM_BIN:-$FNM_DIR/fnm}"
+export FNM_DIR="${FNM_DIR:-/srv/poi/.fnm}"
+FNM_BIN="${FNM_BIN:-/srv/poi/.fnm-bin/fnm}"
 
 if [ ! -x "$FNM_BIN" ]; then
   echo "fnm is required but was not found at $FNM_BIN" >&2

--- a/fnm-exec
+++ b/fnm-exec
@@ -11,6 +11,6 @@ fi
 
 cd /srv/poi
 eval "$("$FNM_BIN" env --shell bash)"
-"$FNM_BIN" use
+"$FNM_BIN" use --install-if-missing
 
 exec "$@"

--- a/fnm-exec
+++ b/fnm-exec
@@ -1,13 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
-if ! command -v fnm >/dev/null 2>&1; then
-  echo "fnm is required but was not found in PATH" >&2
+export FNM_DIR="${FNM_DIR:-/home/poi/.local/share/fnm}"
+FNM_BIN="${FNM_BIN:-$FNM_DIR/fnm}"
+
+if [ ! -x "$FNM_BIN" ]; then
+  echo "fnm is required but was not found at $FNM_BIN" >&2
   exit 127
 fi
 
 cd /srv/poi
-eval "$(fnm env --shell bash)"
-fnm use --install-if-missing
+eval "$("$FNM_BIN" env --shell bash)"
+"$FNM_BIN" use --install-if-missing
 
 exec "$@"

--- a/github-master-hook
+++ b/github-master-hook
@@ -2,6 +2,18 @@
 set -euo pipefail
 
 cd /srv/poi
+
+if [ "${POI_DEPLOY_FROM_TEMP:-0}" != "1" ]; then
+  temp_script="$(mktemp /tmp/poi-server-deploy.XXXXXX)"
+  cp "$0" "$temp_script"
+  chmod +x "$temp_script"
+  POI_DEPLOY_FROM_TEMP=1 exec "$temp_script" "$@"
+fi
+
+case "$0" in
+  /tmp/poi-server-deploy.*) trap 'rm -f "$0"' EXIT ;;
+esac
+
 export FNM_DIR="${FNM_DIR:-/home/poi/.local/share/fnm}"
 FNM_BIN="${FNM_BIN:-$FNM_DIR/fnm}"
 DEPLOY_LOCK="${DEPLOY_LOCK:-/tmp/poi-server-deploy.lock}"

--- a/github-master-hook
+++ b/github-master-hook
@@ -37,6 +37,7 @@ eval "$("$FNM_BIN" env --shell bash)"
 npm ci --omit=dev
 supervisorctl reread
 supervisorctl update
+supervisorctl stop poi || true
 supervisorctl start poi
 supervisorctl restart poi-hook
 

--- a/github-master-hook
+++ b/github-master-hook
@@ -29,9 +29,7 @@ install -m 755 "$BOOTSTRAP_FNM_BIN" "$FNM_BIN"
 
 previous_sha="$(git rev-parse HEAD)"
 git fetch origin
-if supervisorctl status poi | grep -q RUNNING; then
-  supervisorctl stop poi
-fi
+supervisorctl stop poi || true
 git checkout master
 git reset --hard origin/master
 eval "$("$FNM_BIN" env --shell bash)"
@@ -39,11 +37,7 @@ eval "$("$FNM_BIN" env --shell bash)"
 npm ci --omit=dev
 supervisorctl reread
 supervisorctl update
-if supervisorctl status poi | grep -q RUNNING; then
-  supervisorctl restart poi
-else
-  supervisorctl start poi
-fi
+supervisorctl start poi
 supervisorctl restart poi-hook
 
 {

--- a/github-master-hook
+++ b/github-master-hook
@@ -14,17 +14,24 @@ case "$0" in
   /tmp/poi-server-deploy.*) trap 'rm -f "$0"' EXIT ;;
 esac
 
-export FNM_DIR="${FNM_DIR:-/home/poi/.local/share/fnm}"
-FNM_BIN="${FNM_BIN:-$FNM_DIR/fnm}"
+export FNM_DIR="${FNM_DIR:-/srv/poi/.fnm}"
+FNM_BIN="${FNM_BIN:-/srv/poi/.fnm-bin/fnm}"
+BOOTSTRAP_FNM_BIN="${BOOTSTRAP_FNM_BIN:-/home/poi/.local/share/fnm/fnm}"
 DEPLOY_STATE="${DEPLOY_STATE:-/srv/poi/.deploy-state}"
 
-if [ ! -x "$FNM_BIN" ]; then
-  echo "fnm is required but was not found at $FNM_BIN" >&2
+if [ ! -x "$BOOTSTRAP_FNM_BIN" ]; then
+  echo "fnm is required but was not found at $BOOTSTRAP_FNM_BIN" >&2
   exit 127
 fi
 
+mkdir -p "$(dirname "$FNM_BIN")" "$FNM_DIR"
+install -m 755 "$BOOTSTRAP_FNM_BIN" "$FNM_BIN"
+
 previous_sha="$(git rev-parse HEAD)"
 git fetch origin
+if supervisorctl status poi | grep -q RUNNING; then
+  supervisorctl stop poi
+fi
 git checkout master
 git reset --hard origin/master
 eval "$("$FNM_BIN" env --shell bash)"
@@ -32,7 +39,11 @@ eval "$("$FNM_BIN" env --shell bash)"
 npm ci --omit=dev
 supervisorctl reread
 supervisorctl update
-supervisorctl restart poi
+if supervisorctl status poi | grep -q RUNNING; then
+  supervisorctl restart poi
+else
+  supervisorctl start poi
+fi
 supervisorctl restart poi-hook
 
 {

--- a/github-master-hook
+++ b/github-master-hook
@@ -2,10 +2,19 @@
 set -e
 
 cd /srv/poi
+if ! command -v fnm >/dev/null 2>&1; then
+  echo "fnm is required but was not found in PATH" >&2
+  exit 127
+fi
+
 git fetch origin
 supervisorctl stop poi
 git checkout master
 git reset --hard origin/master
+eval "$(fnm env --shell bash)"
+fnm use --install-if-missing
 npm install
+supervisorctl reread
+supervisorctl update
 supervisorctl start poi
 supervisorctl restart poi-hook

--- a/github-master-hook
+++ b/github-master-hook
@@ -1,20 +1,37 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 cd /srv/poi
-if ! command -v fnm >/dev/null 2>&1; then
-  echo "fnm is required but was not found in PATH" >&2
+export FNM_DIR="${FNM_DIR:-/home/poi/.local/share/fnm}"
+FNM_BIN="${FNM_BIN:-$FNM_DIR/fnm}"
+DEPLOY_LOCK="${DEPLOY_LOCK:-/tmp/poi-server-deploy.lock}"
+DEPLOY_STATE="${DEPLOY_STATE:-/srv/poi/.deploy-state}"
+
+if [ ! -x "$FNM_BIN" ]; then
+  echo "fnm is required but was not found at $FNM_BIN" >&2
   exit 127
 fi
 
+exec 9>"$DEPLOY_LOCK"
+if ! flock -n 9; then
+  echo "Another poi-server deployment is already running"
+  exit 0
+fi
+
+previous_sha="$(git rev-parse HEAD)"
 git fetch origin
-supervisorctl stop poi
 git checkout master
 git reset --hard origin/master
-eval "$(fnm env --shell bash)"
-fnm use --install-if-missing
-npm install
+eval "$("$FNM_BIN" env --shell bash)"
+"$FNM_BIN" use --install-if-missing
+npm ci --omit=dev
 supervisorctl reread
 supervisorctl update
-supervisorctl start poi
+supervisorctl restart poi
 supervisorctl restart poi-hook
+
+{
+  echo "previous_sha=$previous_sha"
+  echo "sha=$(git rev-parse HEAD)"
+  echo "deployed_at=$(date --iso-8601=seconds)"
+} >"$DEPLOY_STATE"

--- a/github-master-hook
+++ b/github-master-hook
@@ -16,18 +16,11 @@ esac
 
 export FNM_DIR="${FNM_DIR:-/home/poi/.local/share/fnm}"
 FNM_BIN="${FNM_BIN:-$FNM_DIR/fnm}"
-DEPLOY_LOCK="${DEPLOY_LOCK:-/tmp/poi-server-deploy.lock}"
 DEPLOY_STATE="${DEPLOY_STATE:-/srv/poi/.deploy-state}"
 
 if [ ! -x "$FNM_BIN" ]; then
   echo "fnm is required but was not found at $FNM_BIN" >&2
   exit 127
-fi
-
-exec 9>"$DEPLOY_LOCK"
-if ! flock -n 9; then
-  echo "Another poi-server deployment is already running"
-  exit 0
 fi
 
 previous_sha="$(git rev-parse HEAD)"

--- a/github-master-hook
+++ b/github-master-hook
@@ -19,13 +19,13 @@ FNM_BIN="${FNM_BIN:-/srv/poi/.fnm-bin/fnm}"
 BOOTSTRAP_FNM_BIN="${BOOTSTRAP_FNM_BIN:-/home/poi/.local/share/fnm/fnm}"
 DEPLOY_STATE="${DEPLOY_STATE:-/srv/poi/.deploy-state}"
 
-if [ ! -x "$BOOTSTRAP_FNM_BIN" ]; then
-  echo "fnm is required but was not found at $BOOTSTRAP_FNM_BIN" >&2
+mkdir -p "$(dirname "$FNM_BIN")" "$FNM_DIR"
+if [ -x "$BOOTSTRAP_FNM_BIN" ]; then
+  install -m 755 "$BOOTSTRAP_FNM_BIN" "$FNM_BIN"
+elif [ ! -x "$FNM_BIN" ]; then
+  echo "fnm is required but was not found at $FNM_BIN or $BOOTSTRAP_FNM_BIN" >&2
   exit 127
 fi
-
-mkdir -p "$(dirname "$FNM_BIN")" "$FNM_DIR"
-install -m 755 "$BOOTSTRAP_FNM_BIN" "$FNM_BIN"
 
 previous_sha="$(git rev-parse HEAD)"
 git fetch origin

--- a/supervisior.conf
+++ b/supervisior.conf
@@ -7,8 +7,8 @@ environment=
   POI_SERVER_DISABLE_LOGGER=1,
   POI_SERVER_DB=mongodb://localhost:27017/poi-production,
   POI_SERVER_PORT=17027,
-  FNM_DIR=/home/poi/.local/share/fnm,
-  FNM_BIN=/home/poi/.local/share/fnm/fnm
+  FNM_DIR=/srv/poi/.fnm,
+  FNM_BIN=/srv/poi/.fnm-bin/fnm
 user=www-data
 
 [program:poi-hook]
@@ -17,6 +17,6 @@ directory=/srv/poi
 environment=
   NODE_ENV=production,
   BABEL_DISABLE_CACHE=1,
-  FNM_DIR=/home/poi/.local/share/fnm,
-  FNM_BIN=/home/poi/.local/share/fnm/fnm
+  FNM_DIR=/srv/poi/.fnm,
+  FNM_BIN=/srv/poi/.fnm-bin/fnm
 user=poi

--- a/supervisior.conf
+++ b/supervisior.conf
@@ -1,5 +1,5 @@
 [program:poi]
-command=/usr/bin/node index.js
+command=/srv/poi/fnm-exec node index.js
 directory=/srv/poi
 environment=
   NODE_ENV=production,
@@ -10,7 +10,7 @@ environment=
 user=www-data
 
 [program:poi-hook]
-command=/usr/bin/node hooks.js
+command=/srv/poi/fnm-exec node hooks.js
 directory=/srv/poi
 environment=
   NODE_ENV=production,

--- a/supervisior.conf
+++ b/supervisior.conf
@@ -6,7 +6,9 @@ environment=
   BABEL_DISABLE_CACHE=1,
   POI_SERVER_DISABLE_LOGGER=1,
   POI_SERVER_DB=mongodb://localhost:27017/poi-production,
-  POI_SERVER_PORT=17027
+  POI_SERVER_PORT=17027,
+  FNM_DIR=/home/poi/.local/share/fnm,
+  FNM_BIN=/home/poi/.local/share/fnm/fnm
 user=www-data
 
 [program:poi-hook]
@@ -14,5 +16,7 @@ command=/srv/poi/fnm-exec node hooks.js
 directory=/srv/poi
 environment=
   NODE_ENV=production,
-  BABEL_DISABLE_CACHE=1
+  BABEL_DISABLE_CACHE=1,
+  FNM_DIR=/home/poi/.local/share/fnm,
+  FNM_BIN=/home/poi/.local/share/fnm/fnm
 user=poi


### PR DESCRIPTION
## Summary
- run supervisor-managed poi services through an fnm wrapper that uses `.node-version`
- update the master deploy hook to verify fnm, install/use the pinned Node version, and reload supervisor config
- add line-ending rules and CI validation for deploy hook scripts

## Validation
- bash -n github-master-hook
- bash -n fnm-exec
- npm test
- npm run type-check
- npm run lint -- --quiet