### PR TITLE
Run supervisor services through fnm exec

### DIFF
--- a/fnm-exec
+++ b/fnm-exec
@@ -10,7 +10,5 @@ if [ ! -x "$FNM_BIN" ]; then
 fi
 
 cd /srv/poi
-eval "$("$FNM_BIN" env --shell bash)"
-"$FNM_BIN" use --install-if-missing
 
-exec "$@"
+exec "$FNM_BIN" exec --using .node-version "$@"


### PR DESCRIPTION
## Summary
- run supervisor-launched services via `fnm exec --using .node-version` instead of `fnm env`/`fnm use`
- avoids fnm multishell state creation under the supervisor runtime user

## Validation
- bash -n fnm-exec
- bash -n github-master-hook
- npm run build
- npm test
- npm run type-check
- npm run lint -- --quiet