### PR TITLE
Make deploy hook CRLF check robust

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,4 +35,11 @@ jobs:
         run: |
           bash -n github-master-hook
           bash -n fnm-exec
-          ! grep -Il $'\r' github-master-hook fnm-exec supervisior.conf
+          python - <<'PY'
+          from pathlib import Path
+
+          for name in ("github-master-hook", "fnm-exec", "supervisior.conf"):
+              data = Path(name).read_bytes()
+              if b"\r" in data:
+                  raise SystemExit(f"{name} contains CRLF line endings")
+          PY


### PR DESCRIPTION
## Summary
- replace the deploy-hook CRLF guard with an explicit Python byte check
- fail CI on missing files/read errors instead of masking grep failures

## Validation
- bash -n github-master-hook
- bash -n fnm-exec
- python CRLF check for deploy files
- npm run build
- npm test
- npm run type-check
- npm run lint -- --quiet