### PR TITLE
Run server with tsx

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 * text=auto
 
 *.sh text eol=lf
+*.js text eol=lf
+*.cjs text eol=lf
+*.ts text eol=lf
 *.yaml text eol=lf
 *.yml text eol=lf
 .gitignore text eol=lf

--- a/fnm-exec
+++ b/fnm-exec
@@ -3,6 +3,7 @@ set -euo pipefail
 
 export FNM_DIR="${FNM_DIR:-/srv/poi/.fnm}"
 FNM_BIN="${FNM_BIN:-/srv/poi/.fnm-bin/fnm}"
+export XDG_STATE_HOME="${XDG_STATE_HOME:-/tmp/poi-fnm-state-$(id -u)}"
 
 if [ ! -x "$FNM_BIN" ]; then
   echo "fnm is required but was not found at $FNM_BIN" >&2
@@ -10,5 +11,8 @@ if [ ! -x "$FNM_BIN" ]; then
 fi
 
 cd /srv/poi
+mkdir -p "$XDG_STATE_HOME"
+eval "$("$FNM_BIN" env --shell bash)"
+"$FNM_BIN" use --install-if-missing
 
-exec "$FNM_BIN" exec --using .node-version "$@"
+exec "$@"

--- a/github-master-hook
+++ b/github-master-hook
@@ -33,7 +33,9 @@ supervisorctl stop poi || true
 git checkout master
 git reset --hard origin/master
 "$FNM_BIN" install
-"$FNM_BIN" exec --using .node-version npm ci --omit=dev
+"$FNM_BIN" exec --using .node-version npm ci
+"$FNM_BIN" exec --using .node-version npm run build
+"$FNM_BIN" exec --using .node-version npm prune --omit=dev
 supervisorctl reread
 supervisorctl update
 supervisorctl stop poi || true

--- a/github-master-hook
+++ b/github-master-hook
@@ -33,9 +33,7 @@ supervisorctl stop poi || true
 git checkout master
 git reset --hard origin/master
 "$FNM_BIN" install
-"$FNM_BIN" exec --using .node-version npm ci
-"$FNM_BIN" exec --using .node-version npm run build
-"$FNM_BIN" exec --using .node-version npm prune --omit=dev
+"$FNM_BIN" exec --using .node-version npm ci --omit=dev
 supervisorctl reread
 supervisorctl update
 supervisorctl stop poi || true

--- a/index.js
+++ b/index.js
@@ -1,5 +1,0 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-
-require('dotenv').config()
-
-require('./dist/app.cjs')

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "node-cache": "^5.1.2",
         "node-fetch": "^2.6.1",
         "semver": "^7.3.4",
+        "tsx": "^4.23.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -55,7 +56,6 @@
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-prettier": "^3.3.1",
         "prettier": "^2.2.1",
-        "tsdown": "^0.22.3",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9"
       },
@@ -304,16 +304,6 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.12.11"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
@@ -585,6 +575,422 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
@@ -606,44 +1012,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
     },
     "node_modules/@koa/router": {
       "version": "10.0.0",
@@ -789,19 +1163,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@quansync/fs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-1.0.0.tgz",
-      "integrity": "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "quansync": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sxzz"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1390,13 +1751,6 @@
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.0.tgz",
       "integrity": "sha512-2aoSC4UUbHDj2uCsCxcG/vRMXey/m17bC7UwitVm5hn22nI8O8Y9iDpA76Orc+DWkQ4zZrOKEshCqR/jSuXAHA==",
       "dev": true
-    },
-    "node_modules/@types/jsesc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
-      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.7",
@@ -1994,16 +2348,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/ansis": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
-      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -2071,64 +2415,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/ast-kit": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-3.0.0.tgz",
-      "integrity": "sha512-8OG92q3R35qjC/4i6BLBMg8IB+fClWu/1PEwg2Z9Rn+BuNaiEgJzpzn+pxWOdHJWDCAwu2JP0wCDTozAM4QirQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^8.0.0",
-        "estree-walker": "^3.0.3",
-        "pathe": "^2.0.3"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sxzz"
-      }
-    },
-    "node_modules/ast-kit/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/ast-kit/node_modules/@babel/parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
-      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^8.0.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/ast-kit/node_modules/@babel/types": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/astral-regex": {
@@ -2207,16 +2493,6 @@
       "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
       "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
     },
-    "node_modules/birpc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/birpc/-/birpc-4.0.0.tgz",
-      "integrity": "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
     "node_modules/bl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
@@ -2267,16 +2543,6 @@
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/cac": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
-      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
       }
     },
     "node_modules/cache-content-type": {
@@ -2599,13 +2865,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/defu": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
-      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2684,27 +2943,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dts-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dts-resolver/-/dts-resolver-3.0.0.tgz",
-      "integrity": "sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sxzz"
-      },
-      "peerDependencies": {
-        "oxc-resolver": ">=11.0.0"
-      },
-      "peerDependenciesMeta": {
-        "oxc-resolver": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2715,16 +2953,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "node_modules/empathic": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
-      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -2813,6 +3041,47 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-html": {
@@ -3341,7 +3610,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3412,22 +3680,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "5.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.5.tgz",
-      "integrity": "sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20.20.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -3544,13 +3796,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/hookable": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
-      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
@@ -3687,19 +3932,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/import-without-cache": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/import-without-cache/-/import-without-cache-0.4.0.tgz",
-      "integrity": "sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sxzz"
       }
     },
     "node_modules/imurmurhash": {
@@ -3909,19 +4141,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -5240,23 +5459,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/quansync": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz",
-      "integrity": "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/antfu"
-        },
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/sxzz"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
@@ -5405,16 +5607,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -5472,108 +5664,6 @@
         "@rolldown/binding-wasm32-wasi": "1.1.4",
         "@rolldown/binding-win32-arm64-msvc": "1.1.4",
         "@rolldown/binding-win32-x64-msvc": "1.1.4"
-      }
-    },
-    "node_modules/rolldown-plugin-dts": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.26.0.tgz",
-      "integrity": "sha512-e+kEPtUiDES0htk5iqkSeF4EzAV7R+vugGB44iPDuw1Kw9E+WyL1VG7PaV0IIjGHLiacztMBcMTyrr8ON9CT1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/generator": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.0",
-        "@babel/parser": "^8.0.0",
-        "ast-kit": "^3.0.0",
-        "birpc": "^4.0.0",
-        "dts-resolver": "^3.0.0",
-        "get-tsconfig": "5.0.0-beta.5",
-        "obug": "^2.1.3"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sxzz"
-      },
-      "peerDependencies": {
-        "@ts-macro/tsc": "^0.3.6",
-        "@typescript/native-preview": ">=7.0.0-dev.20260325.1",
-        "rolldown": "^1.0.0",
-        "typescript": "^5.0.0 || ^6.0.0",
-        "vue-tsc": "~3.2.0 || ~3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@ts-macro/tsc": {
-          "optional": true
-        },
-        "@typescript/native-preview": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        },
-        "vue-tsc": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/@babel/generator": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
-      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^8.0.0",
-        "@babel/types": "^8.0.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "@types/jsesc": "^2.5.0",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/@babel/parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
-      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^8.0.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/rolldown-plugin-dts/node_modules/@babel/types": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/run-parallel": {
@@ -6039,16 +6129,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tree-kill": "cli.js"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -6059,92 +6139,6 @@
         "json5": "^1.0.1",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/tsdown": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.22.3.tgz",
-      "integrity": "sha512-louqbfA8Qf//B9jTTL0FPtXTNpjCWv1VPkbcmQMph2pTpzs+LnB1tbe4tDDRVpo2BjF5SgUXaTZe45SxB8pWHg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansis": "^4.3.1",
-        "cac": "^7.0.0",
-        "defu": "^6.1.7",
-        "empathic": "^2.0.1",
-        "hookable": "^6.1.1",
-        "import-without-cache": "^0.4.0",
-        "obug": "^2.1.3",
-        "picomatch": "^4.0.4",
-        "rolldown": "~1.1.1",
-        "rolldown-plugin-dts": "^0.26.0",
-        "semver": "^7.8.4",
-        "tinyexec": "^1.2.4",
-        "tinyglobby": "^0.2.17",
-        "tree-kill": "^1.2.2",
-        "unconfig-core": "^7.5.0"
-      },
-      "bin": {
-        "tsdown": "dist/run.mjs"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sxzz"
-      },
-      "peerDependencies": {
-        "@arethetypeswrong/core": "^0.18.1",
-        "@tsdown/css": "0.22.3",
-        "@tsdown/exe": "0.22.3",
-        "@vitejs/devtools": "*",
-        "publint": "^0.3.8",
-        "tsx": "*",
-        "typescript": "^5.0.0 || ^6.0.0",
-        "unplugin-unused": "^0.5.0",
-        "unrun": "*"
-      },
-      "peerDependenciesMeta": {
-        "@arethetypeswrong/core": {
-          "optional": true
-        },
-        "@tsdown/css": {
-          "optional": true
-        },
-        "@tsdown/exe": {
-          "optional": true
-        },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "publint": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        },
-        "unplugin-unused": {
-          "optional": true
-        },
-        "unrun": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tsdown/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tslib": {
@@ -6173,6 +6167,24 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-check": {
@@ -6220,20 +6232,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/unconfig-core": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/unconfig-core/-/unconfig-core-7.5.0.tgz",
-      "integrity": "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@quansync/fs": "^1.0.0",
-        "quansync": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/undici-types": {
@@ -6797,12 +6795,6 @@
         "@babel/types": "^7.12.11"
       }
     },
-    "@babel/helper-string-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-      "dev": true
-    },
     "@babel/helper-validator-identifier": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
@@ -7040,6 +7032,162 @@
         }
       }
     },
+    "@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "optional": true
+    },
+    "@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "optional": true
+    },
+    "@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "optional": true
+    },
+    "@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "optional": true
+    },
+    "@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "optional": true
+    },
     "@eslint/eslintrc": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
@@ -7058,37 +7206,11 @@
         "strip-json-comments": "^3.1.1"
       }
     },
-    "@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true
-    },
     "@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true
-    },
-    "@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
     },
     "@koa/router": {
       "version": "10.0.0",
@@ -7195,15 +7317,6 @@
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
       "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "dev": true
-    },
-    "@quansync/fs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-1.0.0.tgz",
-      "integrity": "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==",
-      "dev": true,
-      "requires": {
-        "quansync": "^1.0.0"
-      }
     },
     "@rolldown/binding-android-arm64": {
       "version": "1.1.4",
@@ -7614,12 +7727,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.0.tgz",
       "integrity": "sha512-2aoSC4UUbHDj2uCsCxcG/vRMXey/m17bC7UwitVm5hn22nI8O8Y9iDpA76Orc+DWkQ4zZrOKEshCqR/jSuXAHA==",
-      "dev": true
-    },
-    "@types/jsesc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
-      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
       "dev": true
     },
     "@types/json-schema": {
@@ -8081,12 +8188,6 @@
         }
       }
     },
-    "ansis": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
-      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
-      "dev": true
-    },
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -8136,44 +8237,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true
-    },
-    "ast-kit": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-3.0.0.tgz",
-      "integrity": "sha512-8OG92q3R35qjC/4i6BLBMg8IB+fClWu/1PEwg2Z9Rn+BuNaiEgJzpzn+pxWOdHJWDCAwu2JP0wCDTozAM4QirQ==",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "^8.0.0",
-        "estree-walker": "^3.0.3",
-        "pathe": "^2.0.3"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-          "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
-          "dev": true
-        },
-        "@babel/parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
-          "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^8.0.0"
-          }
-        },
-        "@babel/types": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-          "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-string-parser": "^8.0.0",
-            "@babel/helper-validator-identifier": "^8.0.0"
-          }
-        }
-      }
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -8231,12 +8294,6 @@
       "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
       "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
     },
-    "birpc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/birpc/-/birpc-4.0.0.tgz",
-      "integrity": "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==",
-      "dev": true
-    },
     "bl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
@@ -8279,12 +8336,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-    },
-    "cac": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
-      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
-      "dev": true
     },
     "cache-content-type": {
       "version": "1.0.1",
@@ -8543,12 +8594,6 @@
         "object-keys": "^1.0.12"
       }
     },
-    "defu": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
-      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "dev": true
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -8607,13 +8652,6 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
-    "dts-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dts-resolver/-/dts-resolver-3.0.0.tgz",
-      "integrity": "sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==",
-      "dev": true,
-      "requires": {}
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -8623,12 +8661,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "empathic": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
-      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
       "dev": true
     },
     "encodeurl": {
@@ -8699,6 +8731,39 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
+      }
+    },
+    "esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "requires": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "escape-html": {
@@ -9123,7 +9188,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -9173,15 +9237,6 @@
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "requires": {
         "pump": "^3.0.0"
-      }
-    },
-    "get-tsconfig": {
-      "version": "5.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.5.tgz",
-      "integrity": "sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==",
-      "dev": true,
-      "requires": {
-        "resolve-pkg-maps": "^1.0.0"
       }
     },
     "glob": {
@@ -9263,12 +9318,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
-    },
-    "hookable": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
-      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
       "dev": true
     },
     "hosted-git-info": {
@@ -9375,12 +9424,6 @@
           "dev": true
         }
       }
-    },
-    "import-without-cache": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/import-without-cache/-/import-without-cache-0.4.0.tgz",
-      "integrity": "sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==",
-      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -9521,12 +9564,6 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
-    },
-    "jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -10396,12 +10433,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
       "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
     },
-    "quansync": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz",
-      "integrity": "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==",
-      "dev": true
-    },
     "quick-format-unescaped": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
@@ -10519,12 +10550,6 @@
         "path-parse": "^1.0.6"
       }
     },
-    "resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true
-    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -10563,63 +10588,6 @@
         "@rolldown/binding-win32-arm64-msvc": "1.1.4",
         "@rolldown/binding-win32-x64-msvc": "1.1.4",
         "@rolldown/pluginutils": "^1.0.0"
-      }
-    },
-    "rolldown-plugin-dts": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.26.0.tgz",
-      "integrity": "sha512-e+kEPtUiDES0htk5iqkSeF4EzAV7R+vugGB44iPDuw1Kw9E+WyL1VG7PaV0IIjGHLiacztMBcMTyrr8ON9CT1Q==",
-      "dev": true,
-      "requires": {
-        "@babel/generator": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.0",
-        "@babel/parser": "^8.0.0",
-        "ast-kit": "^3.0.0",
-        "birpc": "^4.0.0",
-        "dts-resolver": "^3.0.0",
-        "get-tsconfig": "5.0.0-beta.5",
-        "obug": "^2.1.3"
-      },
-      "dependencies": {
-        "@babel/generator": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
-          "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
-          "dev": true,
-          "requires": {
-            "@babel/parser": "^8.0.0",
-            "@babel/types": "^8.0.0",
-            "@jridgewell/gen-mapping": "^0.3.12",
-            "@jridgewell/trace-mapping": "^0.3.28",
-            "@types/jsesc": "^2.5.0",
-            "jsesc": "^3.0.2"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-          "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
-          "dev": true
-        },
-        "@babel/parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
-          "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^8.0.0"
-          }
-        },
-        "@babel/types": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-          "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-string-parser": "^8.0.0",
-            "@babel/helper-validator-identifier": "^8.0.0"
-          }
-        }
       }
     },
     "run-parallel": {
@@ -10965,12 +10933,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
-    "tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true
-    },
     "tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -10981,37 +10943,6 @@
         "json5": "^1.0.1",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
-      }
-    },
-    "tsdown": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.22.3.tgz",
-      "integrity": "sha512-louqbfA8Qf//B9jTTL0FPtXTNpjCWv1VPkbcmQMph2pTpzs+LnB1tbe4tDDRVpo2BjF5SgUXaTZe45SxB8pWHg==",
-      "dev": true,
-      "requires": {
-        "ansis": "^4.3.1",
-        "cac": "^7.0.0",
-        "defu": "^6.1.7",
-        "empathic": "^2.0.1",
-        "hookable": "^6.1.1",
-        "import-without-cache": "^0.4.0",
-        "obug": "^2.1.3",
-        "picomatch": "^4.0.4",
-        "rolldown": "~1.1.1",
-        "rolldown-plugin-dts": "^0.26.0",
-        "semver": "^7.8.4",
-        "tinyexec": "^1.2.4",
-        "tinyglobby": "^0.2.17",
-        "tree-kill": "^1.2.2",
-        "unconfig-core": "^7.5.0"
-      },
-      "dependencies": {
-        "picomatch": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-          "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-          "dev": true
-        }
       }
     },
     "tslib": {
@@ -11031,6 +10962,15 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
+      }
+    },
+    "tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "requires": {
+        "esbuild": "~0.28.0",
+        "fsevents": "~2.3.3"
       }
     },
     "type-check": {
@@ -11062,16 +11002,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true
-    },
-    "unconfig-core": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/unconfig-core/-/unconfig-core-7.5.0.tgz",
-      "integrity": "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==",
-      "dev": true,
-      "requires": {
-        "@quansync/fs": "^1.0.0",
-        "quansync": "^1.0.0"
-      }
     },
     "undici-types": {
       "version": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "1.0.0",
   "description": "Server side of poi.",
   "private": true,
-  "main": "src/app.ts",
+  "main": "src/index.ts",
   "engines": {
     "node": ">=24"
   },
   "scripts": {
-    "start": "tsx src/app.ts",
+    "start": "tsx src/index.ts",
     "dev": "webpack-dev-server --content-base public/ --config webpack.config.dev.js --colors --watch --inline --progress --hot",
     "build": "node --check hooks.js && node --check scripts/smoke-server.cjs",
     "type-check": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "version": "1.0.0",
   "description": "Server side of poi.",
   "private": true,
-  "main": "index.js",
+  "main": "src/app.ts",
   "engines": {
     "node": ">=24"
   },
   "scripts": {
-    "start": "node --harmony index.js",
+    "start": "tsx src/app.ts",
     "dev": "webpack-dev-server --content-base public/ --config webpack.config.dev.js --colors --watch --inline --progress --hot",
-    "build": "tsdown src/app.ts --format cjs --platform node --target node24 --out-dir dist --clean",
+    "build": "node --check hooks.js && node --check scripts/smoke-server.cjs",
     "type-check": "tsc --noEmit",
     "lint": "eslint . --ext .ts --ext .js",
     "test": "vitest run",
@@ -48,6 +48,7 @@
     "node-cache": "^5.1.2",
     "node-fetch": "^2.6.1",
     "semver": "^7.3.4",
+    "tsx": "^4.23.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -77,7 +78,6 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.1",
     "prettier": "^2.2.1",
-    "tsdown": "^0.22.3",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "dev": "webpack-dev-server --content-base public/ --config webpack.config.dev.js --colors --watch --inline --progress --hot",
-    "build": "node --check hooks.js && node --check scripts/smoke-server.cjs",
+    "build": "npm run type-check && node --check hooks.js && node --check scripts/smoke-server.cjs",
     "type-check": "tsc --noEmit",
     "lint": "eslint . --ext .ts --ext .js",
     "test": "vitest run",

--- a/scripts/smoke-server.cjs
+++ b/scripts/smoke-server.cjs
@@ -65,7 +65,7 @@ const postQuest = async () => {
 
 const tsx = process.platform === 'win32' ? 'node_modules\\.bin\\tsx.cmd' : './node_modules/.bin/tsx'
 
-const server = childProcess.spawn(tsx, ['src/app.ts'], {
+const server = childProcess.spawn(tsx, ['src/index.ts'], {
   stdio: 'inherit',
   env: {
     ...process.env,

--- a/scripts/smoke-server.cjs
+++ b/scripts/smoke-server.cjs
@@ -5,30 +5,67 @@ const baseUrl = `http://127.0.0.1:${port}`
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
-const waitForStatus = async (url, timeoutMs) => {
+const waitFor = async (probe, timeoutMs) => {
   const startedAt = Date.now()
   let lastError
   while (Date.now() - startedAt < timeoutMs) {
     try {
-      const response = await fetch(url)
-      if (response.ok) {
-        const body = await response.json()
-        if (body && body.mongo && typeof body.mongo.Quest === 'number') {
-          return
-        }
-        lastError = new Error(`Unexpected status payload from ${url}`)
-      } else {
-        lastError = new Error(`Unexpected ${response.status} from ${url}`)
+      const result = await probe()
+      if (result) {
+        return result
       }
     } catch (err) {
       lastError = err
     }
     await sleep(500)
   }
-  throw lastError || new Error(`Timed out waiting for ${url}`)
+  throw lastError || new Error('Timed out waiting for smoke check')
 }
 
-const server = childProcess.spawn('node', ['index.js'], {
+const getStatus = async () => {
+  const response = await fetch(`${baseUrl}/api/status`)
+  if (!response.ok) {
+    throw new Error(`Unexpected ${response.status} from /api/status`)
+  }
+  const body = await response.json()
+  if (!body || !body.mongo || typeof body.mongo.Quest !== 'number') {
+    throw new Error('Unexpected /api/status payload')
+  }
+  return body
+}
+
+const waitForStatus = () => waitFor(getStatus, 30000)
+
+const postQuest = async () => {
+  const response = await fetch(`${baseUrl}/api/report/v3/quest`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-reporter': 'smoke-test',
+    },
+    body: JSON.stringify({
+      data: {
+        quests: [
+          {
+            questId: 999001,
+            title: 'Smoke Test Quest',
+            detail: `smoke-${Date.now()}`,
+            category: 1,
+            type: 1,
+          },
+        ],
+      },
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Unexpected ${response.status} from quest report`)
+  }
+}
+
+const tsx = process.platform === 'win32' ? 'node_modules\\.bin\\tsx.cmd' : './node_modules/.bin/tsx'
+
+const server = childProcess.spawn(tsx, ['src/app.ts'], {
   stdio: 'inherit',
   env: {
     ...process.env,
@@ -60,8 +97,14 @@ process.on('SIGTERM', () => {
   process.exit(143)
 })
 
-waitForStatus(`${baseUrl}/api/status`, 30000)
-  .then(() => {
+waitForStatus()
+  .then(async (initialStatus) => {
+    const initialQuestCount = initialStatus.mongo.Quest
+    await postQuest()
+    await waitFor(async () => {
+      const status = await getStatus()
+      return status.mongo.Quest > initialQuestCount ? status : undefined
+    }, 30000)
     cleanup()
   })
   .catch((err) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,5 @@
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+void import('./app')

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,5 +16,5 @@ void import('./sentry-bootstrap')
     } catch (sentryErr) {
       console.error(sentryErr)
     }
-    process.exitCode = 1
+    process.exit(1)
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,19 @@ import dotenv from 'dotenv'
 
 dotenv.config()
 
-void import('./app')
+void import('./sentry-bootstrap')
+  .then(async ({ initSentry }) => {
+    initSentry()
+    await import('./app')
+  })
+  .catch(async (err) => {
+    console.error(err)
+    try {
+      const Sentry = await import('@sentry/node')
+      Sentry.captureException(err)
+      await Sentry.flush(2000)
+    } catch (sentryErr) {
+      console.error(sentryErr)
+    }
+    process.exitCode = 1
+  })

--- a/src/sentry-bootstrap.ts
+++ b/src/sentry-bootstrap.ts
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/node'
+import { Integrations } from '@sentry/tracing'
+
+import { config } from './config'
+
+export const initSentry = (): void => {
+  Sentry.init({
+    dsn: 'https://99bc543aa0984d51917e02a873bb244f@o171991.ingest.sentry.io/5594215',
+    environment: config.env,
+    tracesSampleRate: 0.001,
+    integrations: [new Integrations.Mongo()],
+  })
+}

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,16 +1,7 @@
 import * as Sentry from '@sentry/node'
 import { ExpressRequest } from '@sentry/node/dist/handlers'
-import { extractTraceparentData, stripUrlQueryAndFragment, Integrations } from '@sentry/tracing'
+import { extractTraceparentData, stripUrlQueryAndFragment } from '@sentry/tracing'
 import { DefaultState, DefaultContext, Middleware, ParameterizedContext } from 'koa'
-
-import { config } from './config'
-
-Sentry.init({
-  dsn: 'https://99bc543aa0984d51917e02a873bb244f@o171991.ingest.sentry.io/5594215',
-  environment: config.env,
-  tracesSampleRate: 0.001,
-  integrations: [new Integrations.Mongo()],
-})
 
 export const captureException = (
   err: Error,

--- a/supervisior.conf
+++ b/supervisior.conf
@@ -1,5 +1,5 @@
 [program:poi]
-command=/srv/poi/fnm-exec node index.js
+command=/srv/poi/fnm-exec ./node_modules/.bin/tsx src/app.ts
 directory=/srv/poi
 environment=
   NODE_ENV=production,

--- a/supervisior.conf
+++ b/supervisior.conf
@@ -1,5 +1,5 @@
 [program:poi]
-command=/srv/poi/fnm-exec ./node_modules/.bin/tsx src/app.ts
+command=/srv/poi/fnm-exec ./node_modules/.bin/tsx src/index.ts
 directory=/srv/poi
 environment=
   NODE_ENV=production,


### PR DESCRIPTION
## Summary
- run the server with `tsx src/app.ts` directly and remove the `index.js`/`dist` runtime path
- keep extensionless TypeScript imports while avoiding runtime build artifacts
- keep the stronger Mongo-backed smoke test that writes through the v3 quest API

## Validation
- npm run build
- npm test
- npm run type-check
- npm run lint -- --quiet