### PR TITLE
Remove deploy-time build check

### DIFF
--- a/github-master-hook
+++ b/github-master-hook
@@ -34,7 +34,7 @@ git checkout master
 git reset --hard origin/master
 "$FNM_BIN" install
 "$FNM_BIN" exec --using .node-version npm ci
-"$FNM_BIN" exec --using .node-version npm run build
+
 "$FNM_BIN" exec --using .node-version npm prune --omit=dev
 supervisorctl reread
 supervisorctl update


### PR DESCRIPTION
## Summary
- remove deploy-time `npm run build` from `github-master-hook`
- keep CI as the place where type-check/build validation happens

## Validation
- bash -n github-master-hook