### PR TITLE
fix: restore VS Code TypeScript SDK setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,5 @@
   },
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
-  "js/ts.tsdk.path": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
## Summary
- Restore VS Code's standard `typescript.tsdk` setting key so the workspace TypeScript SDK is picked up correctly

## Validation
- npm run type-check
- npm run lint -- --quiet
- npm test
- npm run build