### PR TITLE
Add server e2e behavior coverage

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,6 +17,11 @@ jobs:
         image: mongo:4.4
         ports:
           - 27017:27017
+        options: >-
+          --health-cmd "mongo --eval 'db.adminCommand({ ping: 1 })'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +33,11 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run type-check
-      - run: npm test
+      - run: npm run test:unit
+      - name: Run e2e tests
+        run: npm run test:e2e
+        env:
+          POI_E2E_MONGODB_URI: mongodb://127.0.0.1:27017/poi-e2e
       - run: npm run build
       - run: npm run smoke
       - name: Validate deploy hooks

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Run e2e tests
         run: npm run test:e2e
         env:
-          POI_E2E_MONGODB_URI: mongodb://127.0.0.1:27017/poi-e2e
+          POI_SERVER_DB: mongodb://127.0.0.1:27017/poi-e2e
       - run: npm run build
       - run: npm run smoke
       - name: Validate deploy hooks

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-prettier": "^5.5.6",
         "globals": "^17.7.0",
+        "mongodb-memory-server": "^11.2.0",
         "prettier": "^3.9.4",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.1",
@@ -773,6 +774,16 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.12.tgz",
+      "integrity": "sha512-QAfAMwNgnYxZ2C6D1HgeP7Gc4i/uvJRim415PCIL9ptRxWMNbWeLBYb2/9R4pGKny/s1FVu2JA2cxCUBUOggrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1544,6 +1555,23 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.62.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
@@ -2155,6 +2183,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/async-mutex/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -2180,6 +2225,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/badge-maker": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/badge-maker/-/badge-maker-3.3.1.tgz",
@@ -2203,6 +2263,104 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.3.tgz",
+      "integrity": "sha512-xRgplks8SvcKkdlv2M6Z2LZmRsmqd+x0nXXGXeMEjwdibj1HSDrlnqBRLeYdMvsgCox7Bq0e+DHwfczOfsn6IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.3.tgz",
+      "integrity": "sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/binary-search": {
       "version": "1.3.6",
@@ -2325,6 +2483,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2388,6 +2559,13 @@
         "raw-body": "^2.3.3",
         "type-is": "^1.6.16"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -3369,6 +3547,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
@@ -3412,6 +3600,13 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3470,6 +3665,24 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3513,6 +3726,27 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -4838,6 +5072,32 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4859,8 +5119,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -4968,6 +5228,191 @@
           "optional": true
         }
       }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
+      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongodb-memory-server": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-11.2.0.tgz",
+      "integrity": "sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "11.2.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-11.2.0.tgz",
+      "integrity": "sha512-vOoDtn0JiLrHvZY81Rp/UtKXXK0rtJHZGZFVnccvJwYitPLNspO0Ty0grqFQOe7iAET8+GI4zAQcphg+R3vxQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.4.3",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.16.0",
+        "https-proxy-agent": "^7.0.6",
+        "mongodb": "^7.2.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.7.3",
+        "tar-stream": "^3.1.8",
+        "tslib": "^2.8.1",
+        "yauzl": "^3.3.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/bson": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
+      "integrity": "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.4.0.tgz",
+      "integrity": "sha512-giySkkdYiwoBFo/oCc8nzov3xOYZ/sB8OpAYk5GINRLEjVw0LDsm8xgQL0XMTyU4extQlDZjhdUr1ZEwKFaazw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^7.2.0",
+        "mongodb-connection-string-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
+        "snappy": "^7.3.2",
+        "socks": "^2.8.6"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/mongodb-memory-server/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/mongodb/node_modules/optional-require": {
       "version": "1.1.10",
@@ -5115,6 +5560,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
       }
     },
     "node_modules/node-cache": {
@@ -5442,6 +5900,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5502,6 +5970,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5549,6 +6024,75 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
       "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==",
       "license": "MIT"
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -6155,8 +6699,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -6196,6 +6740,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/string_decoder": {
@@ -6353,6 +6909,39 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/tinybench": {
@@ -7076,6 +7665,19 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ylru": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
@@ -7476,6 +8078,15 @@
         "koa-compose": "^4.1.0",
         "methods": "^1.1.2",
         "path-to-regexp": "^6.1.0"
+      }
+    },
+    "@mongodb-js/saslprep": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.12.tgz",
+      "integrity": "sha512-QAfAMwNgnYxZ2C6D1HgeP7Gc4i/uvJRim415PCIL9ptRxWMNbWeLBYb2/9R4pGKny/s1FVu2JA2cxCUBUOggrA==",
+      "dev": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "@napi-rs/wasm-runtime": {
@@ -8027,6 +8638,21 @@
         "@types/node": "*"
       }
     },
+    "@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "dev": true
+    },
+    "@types/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+      "dev": true,
+      "requires": {
+        "@types/webidl-conversions": "*"
+      }
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "8.62.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
@@ -8412,6 +9038,23 @@
       "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
       "dev": true
     },
+    "async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+          "dev": true
+        }
+      }
+    },
     "atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -8425,6 +9068,13 @@
       "requires": {
         "possible-typed-array-names": "^1.0.0"
       }
+    },
+    "b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "requires": {}
     },
     "badge-maker": {
       "version": "3.3.1",
@@ -8440,6 +9090,61 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "requires": {}
+    },
+    "bare-fs": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.3.tgz",
+      "integrity": "sha512-xRgplks8SvcKkdlv2M6Z2LZmRsmqd+x0nXXGXeMEjwdibj1HSDrlnqBRLeYdMvsgCox7Bq0e+DHwfczOfsn6IA==",
+      "dev": true,
+      "requires": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      }
+    },
+    "bare-os": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.3.tgz",
+      "integrity": "sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==",
+      "dev": true
+    },
+    "bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "requires": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "requires": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      }
+    },
+    "bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "requires": {
+        "bare-path": "^3.0.0"
+      }
     },
     "binary-search": {
       "version": "1.3.6",
@@ -8525,6 +9230,12 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true
+    },
     "chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -8569,6 +9280,12 @@
         "raw-body": "^2.3.3",
         "type-is": "^1.6.16"
       }
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
     },
     "compressible": {
       "version": "2.0.18",
@@ -9256,6 +9973,15 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "requires": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "execa": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
@@ -9288,6 +10014,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true
+    },
+    "fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -9336,6 +10068,17 @@
         "flat-cache": "^4.0.0"
       }
     },
+    "find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      }
+    },
     "find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -9365,6 +10108,12 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true
     },
     "for-each": {
@@ -10139,6 +10888,23 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
+      }
+    },
     "math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -10153,7 +10919,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "optional": true
+      "devOptional": true
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -10218,6 +10984,122 @@
           "requires": {
             "require-at": "^1.0.6"
           }
+        }
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
+      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
+      "dev": true,
+      "requires": {
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+          "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.3.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "14.2.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+          "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+          "dev": true,
+          "requires": {
+            "tr46": "^5.1.0",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
+      }
+    },
+    "mongodb-memory-server": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-11.2.0.tgz",
+      "integrity": "sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w==",
+      "dev": true,
+      "requires": {
+        "mongodb-memory-server-core": "11.2.0",
+        "tslib": "^2.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+          "dev": true
+        }
+      }
+    },
+    "mongodb-memory-server-core": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-11.2.0.tgz",
+      "integrity": "sha512-vOoDtn0JiLrHvZY81Rp/UtKXXK0rtJHZGZFVnccvJwYitPLNspO0Ty0grqFQOe7iAET8+GI4zAQcphg+R3vxQg==",
+      "dev": true,
+      "requires": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.4.3",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.16.0",
+        "https-proxy-agent": "^7.0.6",
+        "mongodb": "^7.2.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.7.3",
+        "tar-stream": "^3.1.8",
+        "tslib": "^2.8.1",
+        "yauzl": "^3.3.1"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+          "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+          "dev": true
+        },
+        "bson": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
+          "integrity": "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==",
+          "dev": true
+        },
+        "https-proxy-agent": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.1.2",
+            "debug": "4"
+          }
+        },
+        "mongodb": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.4.0.tgz",
+          "integrity": "sha512-giySkkdYiwoBFo/oCc8nzov3xOYZ/sB8OpAYk5GINRLEjVw0LDsm8xgQL0XMTyU4extQlDZjhdUr1ZEwKFaazw==",
+          "dev": true,
+          "requires": {
+            "@mongodb-js/saslprep": "^1.3.0",
+            "bson": "^7.2.0",
+            "mongodb-connection-string-url": "^7.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+          "dev": true
         }
       }
     },
@@ -10318,6 +11200,15 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.4"
+      }
     },
     "node-cache": {
       "version": "5.1.2",
@@ -10524,6 +11415,12 @@
         "p-limit": "^3.0.2"
       }
     },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10564,6 +11461,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
     "picocolors": {
@@ -10607,6 +11510,54 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
       "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
+    },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        }
+      }
     },
     "possible-typed-array-names": {
       "version": "1.1.0",
@@ -11013,7 +11964,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "memory-pager": "^1.0.2"
       }
@@ -11043,6 +11994,17 @@
       "requires": {
         "es-errors": "^1.3.0",
         "internal-slot": "^1.1.0"
+      }
+    },
+    "streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "requires": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "string_decoder": {
@@ -11146,6 +12108,36 @@
       "dev": true,
       "requires": {
         "@pkgr/core": "^0.3.6"
+      }
+    },
+    "tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "requires": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "requires": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "requires": {
+        "b4a": "^1.6.4"
       }
     },
     "tinybench": {
@@ -11544,6 +12536,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
     },
     "ylru": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run",
-    "test:unit": "vitest run tests/sentry.test.ts tests/item-improvement-recipe.test.ts",
+    "test:unit": "vitest run --exclude tests/server.e2e.test.ts",
     "test:e2e": "vitest run tests/server.e2e.test.ts",
     "smoke": "node scripts/smoke-server.cjs"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run",
+    "test:unit": "vitest run tests/sentry.test.ts tests/item-improvement-recipe.test.ts",
+    "test:e2e": "vitest run tests/server.e2e.test.ts",
     "smoke": "node scripts/smoke-server.cjs"
   },
   "repository": {
@@ -67,6 +69,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.6",
     "globals": "^17.7.0",
+    "mongodb-memory-server": "^11.2.0",
     "prettier": "^3.9.4",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,78 +1,11 @@
-import Koa from 'koa'
-import bodyparser from 'koa-bodyparser'
-import cache from 'koa-cash'
-import logger from 'koa-pino-logger'
-import Cache from 'node-cache'
-import mongoose from 'mongoose'
-import childProcess from 'child_process'
-import { trim } from 'lodash'
-import bytes from 'bytes'
-
 import { config } from './config'
-import { captureException, sentryTracingMiddleware } from './sentry'
+import { startServer } from './server'
 
-import './models'
-import { router } from './controllers'
-
-const app = new Koa()
-
-// Database
-mongoose.connect(config.db, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
-  useCreateIndex: true,
-})
-mongoose.connection.on('error', () => {
-  throw new Error('Unable to connect to database at ' + config.db)
-})
-
-app.use(sentryTracingMiddleware)
-
-// Logger
-if (!config.disableLogger) {
-  app.use(logger())
-}
-
-// Cache
-const _cache = new Cache({
-  stdTTL: 10 * 60,
-  checkperiod: 0,
-})
-const cacheCompressionThreshold = bytes('1GB') ?? 1024 ** 3
-app.use(
-  cache({
-    threshold: cacheCompressionThreshold, // Compression is handled by nginx.
-    get: async (key) => _cache.get(key),
-    set: async (key, value, maxAge) => {
-      _cache.set(key, value, maxAge != null && maxAge > 0 ? maxAge : 0)
-    },
-  }),
-)
-
-// Body Parser
-app.use(
-  bodyparser({
-    strict: true,
-    onerror: (err, ctx) => {
-      captureException(err, ctx)
-      console.error(`bodyparser error`)
-    },
-  }),
-)
-
-// Controllers
-app.use(router.routes())
-
-app.listen(config.port, '127.0.0.1', () => {
-  console.log(`Koa is listening on port ${config.port}`)
-})
-
-app.on('error', captureException)
-
-childProcess.exec('git rev-parse HEAD', (err, stdout) => {
-  if (!err) {
-    global.latestCommit = trim(stdout)
-  } else {
+void startServer()
+  .then(() => {
+    console.log(`Koa is listening on port ${config.port}`)
+  })
+  .catch((err) => {
     console.error(err)
-  }
-})
+    process.exit(1)
+  })

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,13 @@
 import { config } from './config'
 import { startServer } from './server'
 
-void startServer()
+void startServer({
+  db: config.db,
+  disableLogger: Boolean(config.disableLogger),
+  host: '127.0.0.1',
+  loadLatestCommit: true,
+  port: config.port,
+})
   .then(() => {
     console.log(`Koa is listening on port ${config.port}`)
   })

--- a/src/create-app.ts
+++ b/src/create-app.ts
@@ -3,7 +3,6 @@ import bodyparser from 'koa-bodyparser'
 import cache from 'koa-cash'
 import logger from 'koa-pino-logger'
 import Cache from 'node-cache'
-import bytes from 'bytes'
 
 import { config } from './config'
 import { captureException, sentryTracingMiddleware } from './sentry'
@@ -14,6 +13,8 @@ import { router } from './controllers'
 interface CreateAppOptions {
   disableLogger?: boolean
 }
+
+const cacheCompressionThreshold = 1024 ** 3
 
 export const createApp = ({
   disableLogger = Boolean(config.disableLogger),
@@ -30,7 +31,6 @@ export const createApp = ({
     stdTTL: 10 * 60,
     checkperiod: 0,
   })
-  const cacheCompressionThreshold = bytes('1GB') ?? 1024 ** 3
   app.use(
     cache({
       threshold: cacheCompressionThreshold,

--- a/src/create-app.ts
+++ b/src/create-app.ts
@@ -1,0 +1,57 @@
+import Koa from 'koa'
+import bodyparser from 'koa-bodyparser'
+import cache from 'koa-cash'
+import logger from 'koa-pino-logger'
+import Cache from 'node-cache'
+import bytes from 'bytes'
+
+import { config } from './config'
+import { captureException, sentryTracingMiddleware } from './sentry'
+
+import './models'
+import { router } from './controllers'
+
+interface CreateAppOptions {
+  disableLogger?: boolean
+}
+
+export const createApp = ({
+  disableLogger = Boolean(config.disableLogger),
+}: CreateAppOptions = {}) => {
+  const app = new Koa()
+
+  app.use(sentryTracingMiddleware)
+
+  if (!disableLogger) {
+    app.use(logger())
+  }
+
+  const _cache = new Cache({
+    stdTTL: 10 * 60,
+    checkperiod: 0,
+  })
+  const cacheCompressionThreshold = bytes('1GB') ?? 1024 ** 3
+  app.use(
+    cache({
+      threshold: cacheCompressionThreshold,
+      get: async (key) => _cache.get(key),
+      set: async (key, value, maxAge) => {
+        _cache.set(key, value, maxAge != null && maxAge > 0 ? maxAge : 0)
+      },
+    }),
+  )
+
+  app.use(
+    bodyparser({
+      strict: true,
+      onerror: (err, ctx) => {
+        captureException(err, ctx)
+        console.error(`bodyparser error`)
+      },
+    }),
+  )
+
+  app.use(router.routes())
+
+  return app
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,8 @@ interface StartedServer {
 const redactMongoCredentials = (message: string) =>
   message.replace(/(mongodb(?:\+srv)?:\/\/)([^:@/?#]+):([^@/?#]+)@/g, '$1<redacted>@')
 
+const getErrorMessage = (err: unknown) => (err instanceof Error ? err.message : String(err))
+
 export const loadLatestCommit = () => {
   childProcess.exec('git rev-parse HEAD', (err, stdout) => {
     if (!err) {
@@ -33,11 +35,17 @@ export const loadLatestCommit = () => {
 }
 
 export const connectDatabase = async (db: string) => {
-  await mongoose.connect(db, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-    useCreateIndex: true,
-  })
+  try {
+    await mongoose.connect(db, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+      useCreateIndex: true,
+    })
+  } catch (err) {
+    throw new Error(
+      `Unable to connect to database: ${redactMongoCredentials(getErrorMessage(err))}`,
+    )
+  }
 }
 
 export const startServer = async ({
@@ -50,7 +58,9 @@ export const startServer = async ({
   await connectDatabase(db)
 
   mongoose.connection.on('error', (err: Error) => {
-    throw new Error(`Unable to connect to database: ${redactMongoCredentials(err.message)}`)
+    throw new Error(
+      `Unable to connect to database: ${redactMongoCredentials(getErrorMessage(err))}`,
+    )
   })
 
   const app = createApp({ disableLogger })

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,9 @@ interface StartedServer {
   close: () => Promise<void>
 }
 
+const redactMongoCredentials = (message: string) =>
+  message.replace(/(mongodb(?:\+srv)?:\/\/)([^:@/?#]+):([^@/?#]+)@/g, '$1<redacted>@')
+
 export const loadLatestCommit = () => {
   childProcess.exec('git rev-parse HEAD', (err, stdout) => {
     if (!err) {
@@ -47,7 +50,7 @@ export const startServer = async ({
   await connectDatabase(db)
 
   mongoose.connection.on('error', (err: Error) => {
-    throw new Error(`Unable to connect to database at ${db}: ${err.message}`)
+    throw new Error(`Unable to connect to database: ${redactMongoCredentials(err.message)}`)
   })
 
   const app = createApp({ disableLogger })

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,78 @@
+import childProcess from 'child_process'
+import { trim } from 'lodash'
+import mongoose from 'mongoose'
+import { type Server } from 'http'
+
+import { config } from './config'
+import { createApp } from './create-app'
+import { captureException } from './sentry'
+
+interface StartServerOptions {
+  db?: string
+  disableLogger?: boolean
+  host?: string
+  loadLatestCommit?: boolean
+  port?: number
+}
+
+interface StartedServer {
+  server: Server
+  close: () => Promise<void>
+}
+
+export const loadLatestCommit = () => {
+  childProcess.exec('git rev-parse HEAD', (err, stdout) => {
+    if (!err) {
+      global.latestCommit = trim(stdout)
+    } else {
+      console.error(err)
+    }
+  })
+}
+
+export const connectDatabase = async (db = config.db) => {
+  await mongoose.connect(db, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+    useCreateIndex: true,
+  })
+}
+
+export const startServer = async ({
+  db = config.db,
+  disableLogger,
+  host = '127.0.0.1',
+  loadLatestCommit: shouldLoadLatestCommit = true,
+  port = config.port,
+}: StartServerOptions = {}): Promise<StartedServer> => {
+  await connectDatabase(db)
+
+  mongoose.connection.on('error', () => {
+    throw new Error('Unable to connect to database at ' + db)
+  })
+
+  const app = createApp({ disableLogger })
+  app.on('error', captureException)
+
+  const server = await new Promise<Server>((resolve) => {
+    const listener = app.listen(port, host, () => resolve(listener))
+  })
+
+  if (shouldLoadLatestCommit) {
+    loadLatestCommit()
+  }
+
+  return {
+    server,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((err) => {
+          if (err != null) {
+            reject(err)
+            return
+          }
+          resolve()
+        })
+      }),
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,16 +3,15 @@ import { trim } from 'lodash'
 import mongoose from 'mongoose'
 import { type Server } from 'http'
 
-import { config } from './config'
 import { createApp } from './create-app'
 import { captureException } from './sentry'
 
 interface StartServerOptions {
-  db?: string
-  disableLogger?: boolean
-  host?: string
-  loadLatestCommit?: boolean
-  port?: number
+  db: string
+  disableLogger: boolean
+  host: string
+  loadLatestCommit: boolean
+  port: number
 }
 
 interface StartedServer {
@@ -30,7 +29,7 @@ export const loadLatestCommit = () => {
   })
 }
 
-export const connectDatabase = async (db = config.db) => {
+export const connectDatabase = async (db: string) => {
   await mongoose.connect(db, {
     useNewUrlParser: true,
     useUnifiedTopology: true,
@@ -39,12 +38,12 @@ export const connectDatabase = async (db = config.db) => {
 }
 
 export const startServer = async ({
-  db = config.db,
+  db,
   disableLogger,
-  host = '127.0.0.1',
-  loadLatestCommit: shouldLoadLatestCommit = true,
-  port = config.port,
-}: StartServerOptions = {}): Promise<StartedServer> => {
+  host,
+  loadLatestCommit: shouldLoadLatestCommit,
+  port,
+}: StartServerOptions): Promise<StartedServer> => {
   await connectDatabase(db)
 
   mongoose.connection.on('error', () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,8 +46,8 @@ export const startServer = async ({
 }: StartServerOptions): Promise<StartedServer> => {
   await connectDatabase(db)
 
-  mongoose.connection.on('error', () => {
-    throw new Error('Unable to connect to database at ' + db)
+  mongoose.connection.on('error', (err: Error) => {
+    throw new Error(`Unable to connect to database at ${db}: ${err.message}`)
   })
 
   const app = createApp({ disableLogger })

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,8 +54,26 @@ export const startServer = async ({
   const app = createApp({ disableLogger })
   app.on('error', captureException)
 
-  const server = await new Promise<Server>((resolve) => {
-    const listener = app.listen(port, host, () => resolve(listener))
+  const server = await new Promise<Server>((resolve, reject) => {
+    const listener = app.listen(port, host)
+
+    function cleanup() {
+      listener.off('error', onError)
+      listener.off('listening', onListening)
+    }
+
+    function onError(err: Error) {
+      cleanup()
+      reject(err)
+    }
+
+    function onListening() {
+      cleanup()
+      resolve(listener)
+    }
+
+    listener.once('error', onError)
+    listener.once('listening', onListening)
   })
 
   if (shouldLoadLatestCommit) {

--- a/tests/server.e2e.test.ts
+++ b/tests/server.e2e.test.ts
@@ -493,7 +493,7 @@ describe('v2 report endpoints', () => {
     })
   })
 
-  test('returns sorted known quests and accepts the legacy quest no-op route', async () => {
+  test('returns known quests in current lexicographic sort order and accepts the legacy quest no-op route', async () => {
     await Quest.create([
       { questId: 2, title: 'B' },
       { questId: 10, title: 'C' },

--- a/tests/server.e2e.test.ts
+++ b/tests/server.e2e.test.ts
@@ -75,6 +75,15 @@ let baseUrl: string
 let mongo: MongoMemoryServer | undefined
 let closeServer: (() => Promise<void>) | undefined
 
+const assertE2eDatabaseUri = (db: string) => {
+  const databaseName = new URL(db).pathname.replace(/^\/+/, '').split('?')[0]
+  if (!databaseName.includes('poi-e2e')) {
+    throw new Error(
+      `Refusing to run e2e tests against non-e2e database: ${databaseName || '<none>'}`,
+    )
+  }
+}
+
 const setupSentryMocks = () => {
   sentryMocks.startTransaction.mockReturnValue({
     finish: sentryMocks.finish,
@@ -205,6 +214,8 @@ beforeAll(async () => {
   if (db == null || db === '') {
     mongo = await MongoMemoryServer.create()
     db = mongo.getUri()
+  } else {
+    assertE2eDatabaseUri(db)
   }
 
   const started = await startServer({

--- a/tests/server.e2e.test.ts
+++ b/tests/server.e2e.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 
 const sentryMocks = vi.hoisted(() => ({
+  addEventProcessor: vi.fn(),
   finish: vi.fn(),
   parseRequest: vi.fn((event) => event),
   setContext: vi.fn(),
@@ -82,6 +83,7 @@ const setupSentryMocks = () => {
   })
   sentryMocks.withScope.mockImplementation((callback) =>
     callback({
+      addEventProcessor: sentryMocks.addEventProcessor,
       setContext: sentryMocks.setContext,
       setTags: sentryMocks.setTags,
       setUser: sentryMocks.setUser,

--- a/tests/server.e2e.test.ts
+++ b/tests/server.e2e.test.ts
@@ -35,7 +35,6 @@ vi.mock('@sindresorhus/df', () => ({
 import childProcess from 'child_process'
 import mongoose from 'mongoose'
 import { MongoMemoryServer } from 'mongodb-memory-server'
-import { type Server as HttpServer } from 'http'
 import { type AddressInfo } from 'net'
 
 import { startServer } from '../src/server'
@@ -73,8 +72,7 @@ interface TestResponse {
 
 let baseUrl: string
 let mongo: MongoMemoryServer | undefined
-let server: HttpServer
-let closeServer: () => Promise<void>
+let closeServer: (() => Promise<void>) | undefined
 
 const setupSentryMocks = () => {
   sentryMocks.startTransaction.mockReturnValue({
@@ -210,12 +208,12 @@ beforeAll(async () => {
   const started = await startServer({
     db,
     disableLogger: true,
+    host: '127.0.0.1',
     loadLatestCommit: false,
     port: 0,
   })
-  server = started.server
   closeServer = started.close
-  const address = server.address() as AddressInfo
+  const address = started.server.address() as AddressInfo
   baseUrl = `http://127.0.0.1:${address.port}`
 })
 
@@ -241,7 +239,7 @@ afterEach(() => {
 })
 
 afterAll(async () => {
-  await closeServer()
+  await closeServer?.()
   await mongoose.disconnect()
   await mongo?.stop()
 })

--- a/tests/server.e2e.test.ts
+++ b/tests/server.e2e.test.ts
@@ -1,0 +1,851 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const sentryMocks = vi.hoisted(() => ({
+  finish: vi.fn(),
+  parseRequest: vi.fn((event) => event),
+  setContext: vi.fn(),
+  setHttpStatus: vi.fn(),
+  setName: vi.fn(),
+  setTags: vi.fn(),
+  setUser: vi.fn(),
+  startTransaction: vi.fn(),
+  withScope: vi.fn(),
+}))
+
+const dfMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@sentry/node', () => ({
+  startTransaction: sentryMocks.startTransaction,
+  withScope: sentryMocks.withScope,
+  captureException: vi.fn(),
+  Handlers: {
+    parseRequest: sentryMocks.parseRequest,
+  },
+}))
+
+vi.mock('@sentry/tracing', () => ({
+  extractTraceparentData: vi.fn(),
+  stripUrlQueryAndFragment: vi.fn((url: string) => url.split('?')[0]),
+}))
+
+vi.mock('@sindresorhus/df', () => ({
+  default: dfMock,
+}))
+
+import childProcess from 'child_process'
+import mongoose from 'mongoose'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import { type Server as HttpServer } from 'http'
+import { type AddressInfo } from 'net'
+
+import { startServer } from '../src/server'
+import {
+  AACIRecord,
+  BattleAPI,
+  CreateItemRecord,
+  CreateShipRecord,
+  DropShipRecord,
+  EnemyInfo,
+  ItemImprovementRecipeAvailabilityFact,
+  ItemImprovementRecipeCostFact,
+  ItemImprovementRecipeUpdateFact,
+  NightBattleCI,
+  NightContactRecord,
+  PassEventRecord,
+  Quest,
+  QuestReward,
+  RecipeRecord,
+  RemodelItemRecord,
+  SelectRankRecord,
+  ShipStat,
+} from '../src/models'
+
+const reporterOrigin = 'Reporter/8.1.0 poi/10.3.99'
+const observedAt = Date.UTC(2026, 6, 3, 15)
+const latestCommit = '0123456789abcdef0123456789abcdef01234567'
+
+interface TestResponse {
+  body: unknown
+  headers: Headers
+  status: number
+  text: string
+}
+
+let baseUrl: string
+let mongo: MongoMemoryServer | undefined
+let server: HttpServer
+let closeServer: () => Promise<void>
+
+const setupSentryMocks = () => {
+  sentryMocks.startTransaction.mockReturnValue({
+    finish: sentryMocks.finish,
+    setHttpStatus: sentryMocks.setHttpStatus,
+    setName: sentryMocks.setName,
+  })
+  sentryMocks.withScope.mockImplementation((callback) =>
+    callback({
+      setContext: sentryMocks.setContext,
+      setTags: sentryMocks.setTags,
+      setUser: sentryMocks.setUser,
+    }),
+  )
+}
+
+const clearMongo = async () => {
+  await Promise.all(
+    Object.values(mongoose.connection.collections).map((collection) => collection.deleteMany({})),
+  )
+}
+
+const request = async (
+  method: string,
+  path: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+): Promise<TestResponse> => {
+  const requestHeaders: Record<string, string> = {
+    accept: 'application/json',
+    ...headers,
+  }
+  let requestBody: string | undefined
+  if (body !== undefined) {
+    requestHeaders['content-type'] = 'application/json'
+    requestBody = JSON.stringify(body)
+  }
+
+  const response = await fetch(`${baseUrl}${path}`, {
+    body: requestBody,
+    headers: requestHeaders,
+    method,
+  })
+  const text = await response.text()
+  const contentType = response.headers.get('content-type') || ''
+
+  return {
+    body: contentType.includes('application/json') && text ? JSON.parse(text) : text,
+    headers: response.headers,
+    status: response.status,
+    text,
+  }
+}
+
+const getReportHeaders = (headers: Record<string, string> = {}) => ({
+  'x-reporter': reporterOrigin,
+  ...headers,
+})
+
+const postReport = (
+  path: string,
+  data: unknown,
+  headers?: Record<string, string>,
+): Promise<TestResponse> => request('POST', path, { data }, getReportHeaders(headers))
+
+const createShipPayload = {
+  items: [30, 30, 30, 30],
+  kdockId: 1,
+  secretary: 100,
+  shipId: 101,
+  highspeed: 0,
+  teitokuLv: 120,
+  largeFlag: false,
+}
+
+const itemImprovementRecords = [
+  {
+    schemaVersion: 1,
+    source: 'list',
+    clientObservedAt: observedAt,
+    recipeId: 33,
+    itemId: 700,
+    day: 6,
+    observedSecondShipId: 0,
+    observedFlagshipId: 101,
+  },
+  {
+    schemaVersion: 1,
+    source: 'detail',
+    clientObservedAt: observedAt,
+    recipeId: 33,
+    itemId: 700,
+    itemLevel: 6,
+    stage: 1,
+    day: 6,
+    observedSecondShipId: 0,
+    observedFlagshipId: 101,
+    fuel: 10,
+    ammo: 20,
+    steel: 30,
+    bauxite: 40,
+    buildkit: 3,
+    remodelkit: 4,
+    certainBuildkit: 5,
+    certainRemodelkit: 6,
+    reqSlotItems: [{ id: 90, count: 2 }],
+    reqUseItems: [{ id: 65, count: 1 }],
+    changeFlag: 0,
+  },
+  {
+    schemaVersion: 1,
+    source: 'execution',
+    clientObservedAt: observedAt,
+    recipeId: 33,
+    itemId: 700,
+    itemLevel: 10,
+    day: 6,
+    observedSecondShipId: 102,
+    observedFlagshipId: 101,
+    upgradeObserved: true,
+    upgradeToItemId: 701,
+    upgradeToItemLevel: 0,
+  },
+]
+
+beforeAll(async () => {
+  let db = process.env.POI_E2E_MONGODB_URI
+  if (db == null || db === '') {
+    mongo = await MongoMemoryServer.create()
+    db = mongo.getUri()
+  }
+
+  const started = await startServer({
+    db,
+    disableLogger: true,
+    loadLatestCommit: false,
+    port: 0,
+  })
+  server = started.server
+  closeServer = started.close
+  const address = server.address() as AddressInfo
+  baseUrl = `http://127.0.0.1:${address.port}`
+})
+
+beforeEach(async () => {
+  setupSentryMocks()
+  dfMock.mockResolvedValue([
+    {
+      filesystem: 'memory',
+      mountpoint: '/',
+      size: 1024,
+      used: 256,
+      available: 768,
+      capacity: 25,
+    },
+  ])
+  vi.spyOn(Date, 'now').mockReturnValue(observedAt)
+  global.latestCommit = latestCommit
+  await clearMongo()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+afterAll(async () => {
+  await closeServer()
+  await mongoose.disconnect()
+  await mongo?.stop()
+})
+
+describe('server common endpoints', () => {
+  test('reports service status using the live database', async () => {
+    await CreateShipRecord.create({ ...createShipPayload, origin: reporterOrigin })
+
+    const response = await request('GET', '/api/status')
+
+    expect(response.status).toBe(200)
+    expect(response.body).toMatchObject({
+      mongo: {
+        CreateShipRecord: 1,
+        CreateItemRecord: 0,
+      },
+    })
+    expect(response.body).toMatchObject({
+      env: process.env.NODE_ENV,
+      disk: [
+        {
+          mountpoint: '/',
+        },
+      ],
+    })
+  })
+
+  test('starts the GitHub master hook process and returns success', async () => {
+    const spawn = vi.spyOn(childProcess, 'spawn').mockReturnValue({
+      on: vi.fn(),
+      stderr: { on: vi.fn() },
+      stdout: { on: vi.fn() },
+    } as any)
+
+    const response = await request('POST', '/api/github-master-hook', {})
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual({ code: 0 })
+    expect(spawn).toHaveBeenCalledWith(expect.stringContaining('github-master-hook'), [])
+  })
+
+  test('returns latest commit and generated service badges', async () => {
+    const latestCommitResponse = await request('GET', '/api/latest-commit')
+    const statusBadgeResponse = await request('GET', '/api/service-status-badge')
+    const versionBadgeResponse = await request('GET', '/api/service-version-badge')
+
+    expect(latestCommitResponse.status).toBe(200)
+    expect(latestCommitResponse.body).toBe(latestCommit)
+    expect(statusBadgeResponse.status).toBe(200)
+    expect(statusBadgeResponse.headers.get('content-type')).toContain('image/svg+xml')
+    expect(statusBadgeResponse.text).toContain('service')
+    expect(statusBadgeResponse.text).toContain('up')
+    expect(versionBadgeResponse.status).toBe(200)
+    expect(versionBadgeResponse.headers.get('content-type')).toContain('image/svg+xml')
+    expect(versionBadgeResponse.text).toContain(latestCommit.slice(0, 8))
+  })
+
+  test('preserves not-found behavior for unknown routes and unsupported methods', async () => {
+    const notFoundResponse = await request('GET', '/api/not-found')
+    const unsupportedMethodResponse = await request('PUT', '/api/status')
+
+    expect(notFoundResponse.status).toBe(404)
+    expect(unsupportedMethodResponse.status).toBe(404)
+  })
+})
+
+describe('v2 report endpoints', () => {
+  test('persists simple report records through HTTP requests', async () => {
+    const cases = [
+      {
+        path: '/api/report/v2/create_ship',
+        model: CreateShipRecord,
+        payload: createShipPayload,
+        expected: { shipId: 101, origin: reporterOrigin },
+      },
+      {
+        path: '/api/report/v2/create_item',
+        model: CreateItemRecord,
+        payload: {
+          items: [10, 20, 30, 40],
+          secretary: 100,
+          itemId: 15,
+          teitokuLv: 120,
+          successful: true,
+        },
+        expected: { itemId: 15, origin: reporterOrigin },
+      },
+      {
+        path: '/api/report/v2/remodel_item',
+        model: RemodelItemRecord,
+        payload: {
+          successful: true,
+          itemId: 200,
+          itemLevel: 6,
+          flagshipId: 100,
+          flagshipLevel: 90,
+          flagshipCond: 49,
+          consortId: 101,
+          consortLevel: 80,
+          consortCond: 50,
+          teitokuLv: 120,
+          certain: false,
+        },
+        expected: { itemId: 200, successful: true },
+      },
+      {
+        path: '/api/report/v2/pass_event',
+        model: PassEventRecord,
+        payload: {
+          teitokuId: 'admiral-1',
+          teitokuLv: 120,
+          mapId: 502,
+          mapLv: 3,
+          rewards: [{ rewardType: 1, rewardId: 2, rewardCount: 3, rewardLevel: 0 }],
+        },
+        expected: { mapId: 502, origin: reporterOrigin },
+      },
+      {
+        path: '/api/report/v2/battle_api',
+        model: BattleAPI,
+        payload: {
+          path: '/kcsapi/api_req_sortie/battle',
+          data: { api_result: 1 },
+        },
+        expected: { path: '/kcsapi/api_req_sortie/battle', origin: reporterOrigin },
+      },
+      {
+        path: '/api/report/v2/night_contcat',
+        model: NightContactRecord,
+        payload: {
+          fleetType: 1,
+          shipId: 100,
+          shipLv: 90,
+          itemId: 102,
+          itemLv: 3,
+          contact: true,
+        },
+        expected: { shipId: 100, contact: true },
+      },
+      {
+        path: '/api/report/v2/night_battle_ci',
+        model: NightBattleCI,
+        payload: {
+          shipId: 100,
+          CI: 'cutin',
+          type: 'torpedo',
+          lv: 99,
+          rawLuck: 50,
+          pos: 1,
+          status: 'normal',
+          items: [1, 2],
+          improvement: [0, 0],
+          searchLight: false,
+          flare: 0,
+          defenseId: 0,
+          defenseTypeId: 0,
+          ciType: 1,
+          display: [1],
+          hitType: [1],
+          damage: [100],
+          damageTotal: 100,
+          time: observedAt,
+        },
+        expected: { shipId: 100, origin: reporterOrigin },
+      },
+    ]
+
+    for (const item of cases) {
+      const response = await postReport(item.path, item.payload)
+
+      expect(response.status).toBe(200)
+      expect(await item.model.countDocuments().exec()).toBe(1)
+      expect(await item.model.findOne(item.expected).lean().exec()).toMatchObject(item.expected)
+    }
+  })
+
+  test('normalizes drop ship snapshots only for non-late maps', async () => {
+    const earlyMapResponse = await postReport('/api/report/v2/drop_ship', {
+      shipId: 1,
+      itemId: 0,
+      mapId: 72,
+      quest: 'A',
+      cellId: 1,
+      enemy: 'enemy',
+      rank: 'S',
+      isBoss: true,
+      teitokuLv: 120,
+      mapLv: 1,
+      enemyShips1: [1],
+      enemyShips2: [],
+      enemyFormation: 1,
+      baseExp: 100,
+      teitokuId: 'admiral-1',
+      shipCounts: [1],
+      ownedShipSnapshot: { 1: [100] },
+    })
+    const lateMapResponse = await postReport('/api/report/v2/drop_ship', {
+      shipId: 2,
+      itemId: 0,
+      mapId: 73,
+      quest: 'A',
+      cellId: 2,
+      enemy: 'enemy',
+      rank: 'S',
+      isBoss: true,
+      teitokuLv: 120,
+      mapLv: 1,
+      enemyShips1: [1],
+      enemyShips2: [],
+      enemyFormation: 1,
+      baseExp: 100,
+      teitokuId: 'admiral-1',
+      shipCounts: [1],
+      ownedShipSnapshot: { 1: [100] },
+    })
+
+    const earlyMapRecord = (await DropShipRecord.findOne({ shipId: 1 }).lean().exec()) as any
+    const lateMapRecord = (await DropShipRecord.findOne({ shipId: 2 }).lean().exec()) as any
+
+    expect(earlyMapResponse.status).toBe(200)
+    expect(lateMapResponse.status).toBe(200)
+    expect(earlyMapRecord.ownedShipSnapshot).toBeUndefined()
+    expect(lateMapRecord.ownedShipSnapshot).toEqual({ 1: [100] })
+  })
+
+  test('upserts select rank records by admiral and map area', async () => {
+    const firstResponse = await postReport('/api/report/v2/select_rank', {
+      teitokuId: 'admiral-1',
+      teitokuLv: 100,
+      mapareaId: 5,
+      rank: 1,
+    })
+    const secondResponse = await postReport('/api/report/v2/select_rank', {
+      teitokuId: 'admiral-1',
+      teitokuLv: 120,
+      mapareaId: 5,
+      rank: 3,
+    })
+
+    const record = await SelectRankRecord.findOne({ teitokuId: 'admiral-1', mapareaId: 5 })
+      .lean()
+      .exec()
+
+    expect(firstResponse.status).toBe(200)
+    expect(secondResponse.status).toBe(200)
+    expect(await SelectRankRecord.countDocuments().exec()).toBe(1)
+    expect(record).toMatchObject({
+      rank: 3,
+      teitokuLv: 120,
+      origin: reporterOrigin,
+    })
+  })
+
+  test('returns sorted known quests and accepts the legacy quest no-op route', async () => {
+    await Quest.create([
+      { questId: 2, title: 'B' },
+      { questId: 10, title: 'C' },
+      { questId: 1, title: 'A' },
+    ])
+
+    const knownQuestsResponse = await request('GET', '/api/report/v2/known_quests')
+    const questNoopResponse = await postReport('/api/report/v2/quest/1', { ignored: true })
+
+    expect(knownQuestsResponse.status).toBe(200)
+    expect(knownQuestsResponse.body).toEqual({ quests: [1, 10, 2] })
+    expect(questNoopResponse.status).toBe(200)
+    expect(await Quest.countDocuments().exec()).toBe(3)
+  })
+
+  test('gates AACI persistence by poi and reporter versions', async () => {
+    const eligibleResponse = await postReport(
+      '/api/report/v2/aaci',
+      {
+        poiVersion: '7.9.2',
+        available: [1],
+        triggered: 1,
+        items: [2],
+        improvement: [0],
+        rawLuck: 50,
+        rawTaiku: 80,
+        lv: 99,
+        hpPercent: 100,
+        pos: 1,
+      },
+      { 'x-reporter': 'Reporter 3.6.0' },
+    )
+    const ineligibleResponse = await postReport(
+      '/api/report/v2/aaci',
+      {
+        poiVersion: '7.9.1',
+        available: [1],
+        triggered: 1,
+        items: [2],
+        improvement: [0],
+        rawLuck: 50,
+        rawTaiku: 80,
+        lv: 99,
+        hpPercent: 100,
+        pos: 1,
+      },
+      { 'x-reporter': 'Reporter 3.6.0' },
+    )
+
+    expect(eligibleResponse.status).toBe(200)
+    expect(ineligibleResponse.status).toBe(200)
+    expect(await AACIRecord.countDocuments().exec()).toBe(1)
+    expect(await AACIRecord.findOne().lean().exec()).toMatchObject({
+      origin: 'Reporter 3.6.0',
+      poiVersion: '7.9.2',
+    })
+  })
+
+  test('returns legacy known recipes and deduplicates remodel recipes', async () => {
+    const knownRecipesResponse = await request('GET', '/api/report/v2/known_recipes')
+    await RecipeRecord.create([
+      { key: 'duplicate', recipeId: 1, itemId: 1 },
+      { key: 'duplicate', recipeId: 2, itemId: 2 },
+    ])
+
+    const dedupeResponse = await request('POST', '/api/report/v2/remodel_recipe_deduplicate', {})
+
+    expect(knownRecipesResponse.status).toBe(200)
+    expect(knownRecipesResponse.body).toEqual({ recipes: [] })
+    expect(dedupeResponse.status).toBe(200)
+    expect(dedupeResponse.body).toMatchObject({ recipes: expect.any(Array) })
+    expect((dedupeResponse.body as { recipes: unknown[] }).recipes).toHaveLength(1)
+    expect(await RecipeRecord.countDocuments({ key: 'duplicate' }).exec()).toBe(1)
+  })
+
+  test('upserts remodel recipes and ignores stage -1 reports', async () => {
+    const payload = {
+      recipeId: 33,
+      itemId: 700,
+      stage: 1,
+      day: 6,
+      secretary: 100,
+      fuel: 10,
+      ammo: 20,
+      steel: 30,
+      bauxite: 40,
+      reqItemId: 90,
+      reqItemCount: 2,
+      buildkit: 3,
+      remodelkit: 4,
+      certainBuildkit: 5,
+      certainRemodelkit: 6,
+      upgradeToItemId: 701,
+      upgradeToItemLevel: 0,
+    }
+
+    const firstResponse = await postReport('/api/report/v2/remodel_recipe', payload)
+    const secondResponse = await postReport('/api/report/v2/remodel_recipe', payload)
+    const ignoredResponse = await postReport('/api/report/v2/remodel_recipe', {
+      ...payload,
+      recipeId: 34,
+      stage: -1,
+    })
+
+    const record = await RecipeRecord.findOne({
+      recipeId: 33,
+      itemId: 700,
+      stage: 1,
+      day: 6,
+      secretary: 100,
+    })
+      .lean()
+      .exec()
+
+    expect(firstResponse.status).toBe(200)
+    expect(secondResponse.status).toBe(200)
+    expect(ignoredResponse.status).toBe(200)
+    expect(record).toMatchObject({ count: 2, origin: reporterOrigin })
+    expect(await RecipeRecord.countDocuments().exec()).toBe(1)
+  })
+
+  test('accepts the legacy night battle ss ci no-op route', async () => {
+    const response = await postReport('/api/report/v2/night_battle_ss_ci', { ignored: true })
+
+    expect(response.status).toBe(200)
+    expect(await NightBattleCI.countDocuments().exec()).toBe(0)
+  })
+
+  test('upserts ship stats and merges enemy info bomber ranges', async () => {
+    const shipStatPayload = {
+      id: 100,
+      lv: 99,
+      los: 80,
+      los_max: 90,
+      asw: 70,
+      asw_max: 80,
+      evasion: 100,
+      evasion_max: 110,
+    }
+    const enemyPayload = {
+      ships1: [1, 2],
+      levels1: [1, 1],
+      hp1: [10, 10],
+      stats1: [[1], [2]],
+      equips1: [[3], [4]],
+      ships2: [],
+      levels2: [],
+      hp2: [],
+      stats2: [],
+      equips2: [],
+      planes: 10,
+      bombersMin: 5,
+      bombersMax: 10,
+    }
+
+    const shipStatResponses = await Promise.all([
+      postReport('/api/report/v2/ship_stat', shipStatPayload),
+      postReport('/api/report/v2/ship_stat', shipStatPayload),
+    ])
+    const enemyInfoResponses = await Promise.all([
+      postReport('/api/report/v2/enemy_info', enemyPayload),
+      postReport('/api/report/v2/enemy_info', {
+        ...enemyPayload,
+        bombersMin: 7,
+        bombersMax: 8,
+      }),
+    ])
+
+    const shipStat = await ShipStat.findOne({ id: 100 }).lean().exec()
+    const enemyInfo = await EnemyInfo.findOne({ ships1: [1, 2], planes: 10 })
+      .lean()
+      .exec()
+
+    expect(shipStatResponses.map((response) => response.status)).toEqual([200, 200])
+    expect(enemyInfoResponses.map((response) => response.status)).toEqual([200, 200])
+    expect(shipStat).toMatchObject({ count: 2 })
+    expect(enemyInfo).toMatchObject({
+      bombersMin: 7,
+      bombersMax: 8,
+      count: 2,
+    })
+  })
+
+  test('returns 400 for malformed and non-object report payloads', async () => {
+    const malformedResponse = await postReport('/api/report/v2/create_ship', '{')
+    const nonObjectResponse = await postReport('/api/report/v2/create_ship', 1)
+
+    expect(malformedResponse.status).toBe(400)
+    expect(malformedResponse.body).toEqual({ error: 'data must be valid JSON' })
+    expect(nonObjectResponse.status).toBe(400)
+    expect(nonObjectResponse.body).toEqual({ error: 'data must be a JSON object' })
+    expect(await CreateShipRecord.countDocuments().exec()).toBe(0)
+  })
+})
+
+describe('v3 report endpoints', () => {
+  test('ingests item improvement facts and exports every fact type', async () => {
+    const ingestResponse = await postReport('/api/report/v3/item_improvement_recipe', {
+      records: itemImprovementRecords,
+    })
+    const availabilityResponse = await request(
+      'GET',
+      '/api/report/v3/item_improvement_recipes/availability?updatedAfter=0&limit=5000',
+    )
+    const costsResponse = await request('GET', '/api/report/v3/item_improvement_recipes/costs')
+    const updatesResponse = await request('GET', '/api/report/v3/item_improvement_recipes/updates')
+
+    expect(ingestResponse.status).toBe(200)
+    expect(ingestResponse.body).toEqual({ records: 3 })
+    expect(await ItemImprovementRecipeAvailabilityFact.countDocuments().exec()).toBe(1)
+    expect(await ItemImprovementRecipeCostFact.countDocuments().exec()).toBe(1)
+    expect(await ItemImprovementRecipeUpdateFact.countDocuments().exec()).toBe(1)
+    expect(availabilityResponse.status).toBe(200)
+    expect(availabilityResponse.body).toMatchObject({
+      next: {
+        updatedAfter: observedAt,
+        afterId: expect.any(String),
+      },
+      records: [
+        {
+          key: 'v1|availability|33|700|6|0',
+          count: 1,
+          sources: ['list'],
+        },
+      ],
+    })
+    expect(
+      (availabilityResponse.body as { records: Array<Record<string, unknown>> }).records[0],
+    ).not.toHaveProperty('origins')
+    expect(costsResponse.status).toBe(200)
+    expect(costsResponse.body).toMatchObject({
+      records: [
+        {
+          key: 'v1|cost|33|700|6|1|6|0|10|20|30|40|3|4|5|6|90:2|65:1|0',
+        },
+      ],
+    })
+    expect(updatesResponse.status).toBe(200)
+    expect(updatesResponse.body).toMatchObject({
+      records: [
+        {
+          key: 'v1|update|33|700|10|6|102|701|0',
+        },
+      ],
+    })
+  })
+
+  test('exports item improvement facts after a cursor', async () => {
+    await postReport('/api/report/v3/item_improvement_recipe', {
+      records: itemImprovementRecords,
+    })
+    const firstPage = await request(
+      'GET',
+      '/api/report/v3/item_improvement_recipes/availability?updatedAfter=0&limit=1',
+    )
+    const next = (firstPage.body as { next: { updatedAfter: number; afterId: string } }).next
+
+    const secondPage = await request(
+      'GET',
+      `/api/report/v3/item_improvement_recipes/availability?updatedAfter=${next.updatedAfter}&afterId=${next.afterId}`,
+    )
+
+    expect(firstPage.status).toBe(200)
+    expect(secondPage.status).toBe(200)
+    expect(secondPage.body).toEqual({ records: [], next: null })
+  })
+
+  test('returns 400 for invalid item improvement payloads and cursors', async () => {
+    const malformedResponse = await postReport('/api/report/v3/item_improvement_recipe', '{')
+    const invalidRecordResponse = await postReport('/api/report/v3/item_improvement_recipe', {
+      ...itemImprovementRecords[1],
+      reqUseItems: [{ id: 65, count: 0 }],
+    })
+    const oversizedBatchResponse = await postReport('/api/report/v3/item_improvement_recipe', {
+      records: Array.from({ length: 101 }, () => itemImprovementRecords[0]),
+    })
+    const invalidCursorResponse = await request(
+      'GET',
+      '/api/report/v3/item_improvement_recipes/availability?afterId=invalid-object-id',
+    )
+
+    expect(malformedResponse.status).toBe(400)
+    expect(malformedResponse.body).toEqual({ error: 'data must be valid JSON' })
+    expect(invalidRecordResponse.status).toBe(400)
+    expect(invalidRecordResponse.body).toEqual({
+      error: 'reqUseItems.0: must contain positive id and count',
+    })
+    expect(oversizedBatchResponse.status).toBe(400)
+    expect(oversizedBatchResponse.body).toEqual({
+      error: 'records: Too big: expected array to have <=100 items',
+    })
+    expect(invalidCursorResponse.status).toBe(400)
+    expect(invalidCursorResponse.body).toEqual({ error: 'afterId: must be a valid ObjectId' })
+  })
+
+  test('upserts quests, exposes known quest prefixes, and stores quest rewards', async () => {
+    const questResponse = await postReport(
+      '/api/report/v3/quest',
+      JSON.stringify({
+        quests: [
+          {
+            questId: 801,
+            category: 2,
+            type: 1,
+            title: 'Test quest',
+            detail: 'Test details',
+          },
+        ],
+      }),
+    )
+    const knownQuestsResponse = await request('GET', '/api/report/v3/known_quests')
+    const rewardResponse = await postReport('/api/report/v3/quest_reward', {
+      questId: 901,
+      title: 'Reward quest',
+      detail: 'Reward details',
+      category: 2,
+      type: 1,
+      selections: [1],
+      material: [0, 0, 0, 0],
+      bonus: [{ type: 'item', id: 1 }],
+      bounsCount: 1,
+    })
+
+    const quest = await Quest.findOne({ questId: 801 }).lean().exec()
+    const reward = await QuestReward.findOne({ questId: 901 }).lean().exec()
+
+    expect(questResponse.status).toBe(200)
+    expect(quest).toMatchObject({
+      key: '8b6799d18daec4c67b34b883f9cfc2d0',
+      origin: reporterOrigin,
+    })
+    expect(knownQuestsResponse.status).toBe(200)
+    expect(knownQuestsResponse.body).toEqual({ quests: ['8b6799d1'] })
+    expect(rewardResponse.status).toBe(200)
+    expect(reward).toMatchObject({
+      key: '12bd88872bd8320b5900b36276e8050e',
+      origin: reporterOrigin,
+      selections: [1],
+      bounsCount: 1,
+    })
+  })
+
+  test('returns 400 for malformed and missing v3 report payloads', async () => {
+    const malformedResponse = await postReport('/api/report/v3/quest', '{')
+    const missingResponse = await request('POST', '/api/report/v3/quest', {}, getReportHeaders())
+
+    expect(malformedResponse.status).toBe(400)
+    expect(malformedResponse.body).toEqual({ error: 'data must be valid JSON' })
+    expect(missingResponse.status).toBe(400)
+    expect(missingResponse.body).toEqual({ error: 'data must be a JSON object' })
+    expect(await Quest.countDocuments().exec()).toBe(0)
+  })
+})

--- a/tests/server.e2e.test.ts
+++ b/tests/server.e2e.test.ts
@@ -201,7 +201,7 @@ const itemImprovementRecords = [
 ]
 
 beforeAll(async () => {
-  let db = process.env.POI_E2E_MONGODB_URI
+  let db = process.env.POI_SERVER_DB
   if (db == null || db === '') {
     mongo = await MongoMemoryServer.create()
     db = mongo.getUri()

--- a/tests/server.e2e.test.ts
+++ b/tests/server.e2e.test.ts
@@ -75,12 +75,26 @@ let baseUrl: string
 let mongo: MongoMemoryServer | undefined
 let closeServer: (() => Promise<void>) | undefined
 
+const localMongoHosts = new Set(['localhost', '127.0.0.1', '::1'])
+
+const getMongoHostName = (host: string) => {
+  if (host.startsWith('[')) {
+    return host.slice(1, host.indexOf(']'))
+  }
+  return host.split(':')[0]
+}
+
 const assertE2eDatabaseUri = (db: string) => {
-  const databaseName = new URL(db).pathname.replace(/^\/+/, '').split('?')[0]
+  const url = new URL(db)
+  const databaseName = url.pathname.replace(/^\/+/, '').split('?')[0]
   if (!databaseName.includes('poi-e2e')) {
     throw new Error(
       `Refusing to run e2e tests against non-e2e database: ${databaseName || '<none>'}`,
     )
+  }
+  const hosts = url.host.split(',').map(getMongoHostName)
+  if (hosts.some((host) => !localMongoHosts.has(host))) {
+    throw new Error('Refusing to run e2e tests against non-local MongoDB host')
   }
 }
 


### PR DESCRIPTION
## Summary
- add full-server HTTP e2e coverage for current Koa behavior before Fastify migration
- boot e2e tests with the real middleware/router stack and MongoDB-backed persistence
- split CI tests into explicit unit and e2e steps, with e2e using the workflow Mongo service

## Validation
- npm run type-check
- npm run lint -- --quiet
- npm run test:unit
- npm run test:e2e
- npm run build

Closes #64