### PR TITLE
Fix poi-hook server after Fastify migration

### DIFF
--- a/hooks.js
+++ b/hooks.js
@@ -20,7 +20,7 @@ const createHookApp = ({ runHook = runMasterHook } = {}) => {
 
   app.post('/api/github-master-hook', async (_request, reply) => {
     runHook()
-    return reply.type('text/plain; charset=utf-8').send('ok')
+    return reply.code(200).send()
   })
 
   app.setNotFoundHandler(async (_request, reply) =>

--- a/hooks.js
+++ b/hooks.js
@@ -1,18 +1,10 @@
 const ChildProcess = require('child_process')
-const http = require('http')
+const Fastify = require('fastify')
 
 require('dotenv').config()
 
 const defaultPort = 11280
 const defaultHost = '127.0.0.1'
-
-const send = (res, statusCode, body = '') => {
-  res.writeHead(statusCode, {
-    'content-length': Buffer.byteLength(body),
-    'content-type': 'text/plain; charset=utf-8',
-  })
-  res.end(body)
-}
 
 const runMasterHook = () => {
   console.log(`====================Master hook ${new Date()} ====================`)
@@ -23,34 +15,36 @@ const runMasterHook = () => {
   cp.on('close', (code) => console.log('* Master hook exit code:' + code))
 }
 
-const createHookServer = ({ runHook = runMasterHook } = {}) =>
-  http.createServer((req, res) => {
-    let path
-    try {
-      path = new URL(req.url || '/', `http://${defaultHost}:${defaultPort}`).pathname
-    } catch {
-      send(res, 400, 'bad request')
-      return
-    }
+const createHookApp = ({ runHook = runMasterHook } = {}) => {
+  const app = Fastify({ logger: false })
 
-    if (req.method === 'POST' && path === '/api/github-master-hook') {
-      runHook()
-      send(res, 200, 'ok')
-      return
-    }
-
-    send(res, 404, 'not found')
+  app.post('/api/github-master-hook', async (_request, reply) => {
+    runHook()
+    return reply.type('text/plain; charset=utf-8').send('ok')
   })
+
+  app.setNotFoundHandler(async (_request, reply) =>
+    reply.code(404).type('text/plain; charset=utf-8').send('not found'),
+  )
+
+  return app
+}
 
 if (require.main === module) {
-  const server = createHookServer()
-  server.listen(defaultPort, defaultHost, () => {
-    console.log(`Server is listening at port ${defaultPort}`)
-  })
+  const app = createHookApp()
+  app
+    .listen({ host: defaultHost, port: defaultPort })
+    .then(() => {
+      console.log(`Server is listening at port ${defaultPort}`)
+    })
+    .catch((err) => {
+      console.error(err)
+      process.exit(1)
+    })
 }
 
 module.exports = {
-  createHookServer,
+  createHookApp,
   defaultHost,
   defaultPort,
   runMasterHook,

--- a/hooks.js
+++ b/hooks.js
@@ -1,22 +1,53 @@
-const Koa = require('koa')
-const Router = require('@koa/router')
 const ChildProcess = require('child_process')
+const http = require('http')
+
 require('dotenv').config()
 
-const app = new Koa()
-const router = new Router()
+const defaultPort = 11280
+const defaultHost = '127.0.0.1'
 
-router.post('/api/github-master-hook', async (ctx, next) => {
+const send = (res, statusCode, body = '') => {
+  res.writeHead(statusCode, {
+    'content-length': Buffer.byteLength(body),
+    'content-type': 'text/plain; charset=utf-8',
+  })
+  res.end(body)
+}
+
+const runMasterHook = () => {
   console.log(`====================Master hook ${new Date()} ====================`)
-  const cp = ChildProcess.spawn('./github-master-hook', { stdio: 'inherit' })
+  const cp = ChildProcess.spawn('./github-master-hook', [], {
+    stdio: 'inherit',
+  })
+  cp.on('error', (err) => console.error('* Master hook spawn error:', err))
   cp.on('close', (code) => console.log('* Master hook exit code:' + code))
-  ctx.status = 200
-  await next()
-})
+}
 
-// Start server
-const Port = 11280
-app.use(router.routes())
-app.listen(Port, '127.0.0.1', () => {
-  console.log(`Server is listening at port ${Port}`)
-})
+const createHookServer = ({ runHook = runMasterHook } = {}) =>
+  http.createServer((req, res) => {
+    const path = new URL(
+      req.url || '/',
+      `http://${req.headers.host || `${defaultHost}:${defaultPort}`}`,
+    ).pathname
+    if (req.method === 'POST' && path === '/api/github-master-hook') {
+      runHook()
+      send(res, 200, 'ok')
+      return
+    }
+
+    send(res, 404, 'not found')
+  })
+
+if (require.main === module) {
+  const server = createHookServer()
+  server.listen(defaultPort, defaultHost, () => {
+    console.log(`Server is listening at port ${defaultPort}`)
+  })
+}
+
+module.exports = {
+  createHookServer,
+  defaultHost,
+  defaultPort,
+  runMasterHook,
+}

--- a/hooks.js
+++ b/hooks.js
@@ -25,10 +25,14 @@ const runMasterHook = () => {
 
 const createHookServer = ({ runHook = runMasterHook } = {}) =>
   http.createServer((req, res) => {
-    const path = new URL(
-      req.url || '/',
-      `http://${req.headers.host || `${defaultHost}:${defaultPort}`}`,
-    ).pathname
+    let path
+    try {
+      path = new URL(req.url || '/', `http://${defaultHost}:${defaultPort}`).pathname
+    } catch {
+      send(res, 400, 'bad request')
+      return
+    }
+
     if (req.method === 'POST' && path === '/api/github-master-hook') {
       runHook()
       send(res, 200, 'ok')

--- a/hooks.ts
+++ b/hooks.ts
@@ -1,12 +1,16 @@
-const ChildProcess = require('child_process')
-const Fastify = require('fastify')
+import ChildProcess from 'child_process'
+import Fastify, { type FastifyInstance } from 'fastify'
 
-require('dotenv').config()
+import 'dotenv/config'
 
-const defaultPort = 11280
-const defaultHost = '127.0.0.1'
+export const defaultPort = 11280
+export const defaultHost = '127.0.0.1'
 
-const runMasterHook = () => {
+interface CreateHookAppOptions {
+  runHook?: () => void
+}
+
+export const runMasterHook = () => {
   console.log(`====================Master hook ${new Date()} ====================`)
   const cp = ChildProcess.spawn('./github-master-hook', [], {
     stdio: 'inherit',
@@ -15,7 +19,9 @@ const runMasterHook = () => {
   cp.on('close', (code) => console.log('* Master hook exit code:' + code))
 }
 
-const createHookApp = ({ runHook = runMasterHook } = {}) => {
+export const createHookApp = ({
+  runHook = runMasterHook,
+}: CreateHookAppOptions = {}): FastifyInstance => {
   const app = Fastify({ logger: false })
 
   app.post('/api/github-master-hook', async (_request, reply) => {
@@ -41,11 +47,4 @@ if (require.main === module) {
       console.error(err)
       process.exit(1)
     })
-}
-
-module.exports = {
-  createHookApp,
-  defaultHost,
-  defaultPort,
-  runMasterHook,
 }

--- a/hooks.ts
+++ b/hooks.ts
@@ -1,4 +1,5 @@
 import ChildProcess from 'child_process'
+import path from 'path'
 import Fastify, { type FastifyInstance } from 'fastify'
 
 import 'dotenv/config'
@@ -12,7 +13,7 @@ interface CreateHookAppOptions {
 
 export const runMasterHook = () => {
   console.log(`====================Master hook ${new Date()} ====================`)
-  const cp = ChildProcess.spawn('./github-master-hook', [], {
+  const cp = ChildProcess.spawn(path.resolve(__dirname, 'github-master-hook'), [], {
     stdio: 'inherit',
   })
   cp.on('error', (err) => console.error('* Master hook spawn error:', err))

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "dev": "webpack-dev-server --content-base public/ --config webpack.config.dev.js --colors --watch --inline --progress --hot",
-    "build": "npm run type-check && node --check hooks.js && node --check scripts/smoke-server.cjs",
+    "build": "npm run type-check && node --check scripts/smoke-server.cjs",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run",

--- a/shims/global.d.ts
+++ b/shims/global.d.ts
@@ -1,0 +1,15 @@
+export {}
+
+declare global {
+  var latestCommit: string
+
+  interface GlobalThis {
+    latestCommit: string
+  }
+
+  namespace NodeJS {
+    interface Global {
+      latestCommit: string
+    }
+  }
+}

--- a/shims/index.d.ts
+++ b/shims/index.d.ts
@@ -1,17 +1,3 @@
-interface GlobalThis {
-  latestCommit: string
-}
-
-declare const global: typeof globalThis & {
-  latestCommit: string
-}
-
-declare namespace NodeJS {
-  interface Global {
-    latestCommit: GlobalThis['latestCommit']
-  }
-}
-
 declare module 'dotenv' {
   export interface DotenvConfigOptions {
     path?: string

--- a/supervisior.conf
+++ b/supervisior.conf
@@ -12,7 +12,7 @@ environment=
 user=www-data
 
 [program:poi-hook]
-command=/srv/poi/fnm-exec node hooks.js
+command=/srv/poi/fnm-exec ./node_modules/.bin/tsx hooks.ts
 directory=/srv/poi
 environment=
   NODE_ENV=production,

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,11 +1,14 @@
-import { createRequire } from 'module'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { type FastifyInstance } from 'fastify'
 
-const requireHook = createRequire(__filename)
-
-const { createHookApp } = requireHook('../hooks.js') as {
+interface HookModule {
   createHookApp: (options?: { runHook?: () => void }) => FastifyInstance
+}
+
+const loadHookModule = async (): Promise<HookModule> => {
+  const hookPath = '../hooks.js'
+  const mod = (await import(hookPath)) as { default?: HookModule } & Partial<HookModule>
+  return mod.default ?? (mod as HookModule)
 }
 
 let app: FastifyInstance | undefined
@@ -17,6 +20,7 @@ afterEach(async () => {
 
 describe('poi hook server', () => {
   test('runs the deploy hook for GitHub master hook POSTs', async () => {
+    const { createHookApp } = await loadHookModule()
     const runHook = vi.fn()
     app = createHookApp({ runHook })
 
@@ -31,6 +35,7 @@ describe('poi hook server', () => {
   })
 
   test('returns 404 without running the deploy hook for other requests', async () => {
+    const { createHookApp } = await loadHookModule()
     const runHook = vi.fn()
     app = createHookApp({ runHook })
 

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,0 +1,70 @@
+import { type Server } from 'http'
+import { createRequire } from 'module'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const requireHook = createRequire(__filename)
+
+const { createHookServer } = requireHook('../hooks.js') as {
+  createHookServer: (options?: { runHook?: () => void }) => Server
+}
+
+let server: Server | undefined
+
+const listen = async (target: Server): Promise<string> =>
+  new Promise((resolve, reject) => {
+    target.once('error', reject)
+    target.listen(0, '127.0.0.1', () => {
+      target.off('error', reject)
+      const address = target.address()
+      if (address == null || typeof address === 'string') {
+        reject(new Error('Hook test server did not bind to a TCP port'))
+        return
+      }
+      resolve(`http://127.0.0.1:${address.port}`)
+    })
+  })
+
+afterEach(
+  () =>
+    new Promise<void>((resolve, reject) => {
+      if (server == null || !server.listening) {
+        server = undefined
+        resolve()
+        return
+      }
+      server.close((err) => {
+        server = undefined
+        if (err != null) {
+          reject(err)
+          return
+        }
+        resolve()
+      })
+    }),
+)
+
+describe('poi hook server', () => {
+  test('runs the deploy hook for GitHub master hook POSTs', async () => {
+    const runHook = vi.fn()
+    server = createHookServer({ runHook })
+    const baseUrl = await listen(server)
+
+    const response = await fetch(`${baseUrl}/api/github-master-hook`, { method: 'POST' })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('ok')
+    expect(runHook).toHaveBeenCalledTimes(1)
+  })
+
+  test('returns 404 without running the deploy hook for other requests', async () => {
+    const runHook = vi.fn()
+    server = createHookServer({ runHook })
+    const baseUrl = await listen(server)
+
+    const response = await fetch(`${baseUrl}/api/github-master-hook`)
+
+    expect(response.status).toBe(404)
+    expect(await response.text()).toBe('not found')
+    expect(runHook).not.toHaveBeenCalled()
+  })
+})

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,4 +1,5 @@
 import { type Server } from 'http'
+import net, { type Socket } from 'net'
 import { createRequire } from 'module'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
@@ -32,6 +33,7 @@ afterEach(
         resolve()
         return
       }
+      server.closeIdleConnections?.()
       server.close((err) => {
         server = undefined
         if (err != null) {
@@ -65,6 +67,31 @@ describe('poi hook server', () => {
 
     expect(response.status).toBe(404)
     expect(await response.text()).toBe('not found')
+    expect(runHook).not.toHaveBeenCalled()
+  })
+
+  test('returns 400 for malformed request URLs without running the deploy hook', async () => {
+    const runHook = vi.fn()
+    server = createHookServer({ runHook })
+    const baseUrl = await listen(server)
+
+    const socket = await new Promise<Socket>((resolve, reject) => {
+      const client = net.connect(Number(new URL(baseUrl).port), '127.0.0.1')
+      client.once('connect', () => resolve(client))
+      client.once('error', reject)
+    })
+
+    const response = await new Promise<string>((resolve) => {
+      let data = ''
+      socket.on('data', (chunk) => {
+        data += chunk.toString()
+      })
+      socket.on('end', () => resolve(data))
+      socket.end('GET http://% HTTP/1.1\r\nHost: invalid\r\nConnection: close\r\n\r\n')
+    })
+
+    expect(response).toContain('400')
+    expect(response).toContain('bad request')
     expect(runHook).not.toHaveBeenCalled()
   })
 })

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
+import ChildProcess from 'child_process'
 import { type FastifyInstance } from 'fastify'
+import path from 'path'
+import { EventEmitter } from 'events'
 
-import { createHookApp } from '../hooks'
+import { createHookApp, runMasterHook } from '../hooks'
 
 let app: FastifyInstance | undefined
 
@@ -34,5 +37,21 @@ describe('poi hook server', () => {
     expect(response.statusCode).toBe(404)
     expect(response.body).toBe('not found')
     expect(runHook).not.toHaveBeenCalled()
+  })
+
+  test('spawns the deploy script using an absolute path', () => {
+    const child = new EventEmitter()
+    const spawn = vi.spyOn(ChildProcess, 'spawn').mockReturnValue(child as never)
+
+    runMasterHook()
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.stringMatching(
+        new RegExp(`${path.sep === '\\' ? '\\\\' : path.sep}github-master-hook$`),
+      ),
+      [],
+      { stdio: 'inherit' },
+    )
+    expect(path.isAbsolute(spawn.mock.calls[0][0] as string)).toBe(true)
   })
 })

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,97 +1,43 @@
-import { type Server } from 'http'
-import net, { type Socket } from 'net'
 import { createRequire } from 'module'
 import { afterEach, describe, expect, test, vi } from 'vitest'
+import { type FastifyInstance } from 'fastify'
 
 const requireHook = createRequire(__filename)
 
-const { createHookServer } = requireHook('../hooks.js') as {
-  createHookServer: (options?: { runHook?: () => void }) => Server
+const { createHookApp } = requireHook('../hooks.js') as {
+  createHookApp: (options?: { runHook?: () => void }) => FastifyInstance
 }
 
-let server: Server | undefined
+let app: FastifyInstance | undefined
 
-const listen = async (target: Server): Promise<string> =>
-  new Promise((resolve, reject) => {
-    target.once('error', reject)
-    target.listen(0, '127.0.0.1', () => {
-      target.off('error', reject)
-      const address = target.address()
-      if (address == null || typeof address === 'string') {
-        reject(new Error('Hook test server did not bind to a TCP port'))
-        return
-      }
-      resolve(`http://127.0.0.1:${address.port}`)
-    })
-  })
-
-afterEach(
-  () =>
-    new Promise<void>((resolve, reject) => {
-      if (server == null || !server.listening) {
-        server = undefined
-        resolve()
-        return
-      }
-      server.closeIdleConnections?.()
-      server.close((err) => {
-        server = undefined
-        if (err != null) {
-          reject(err)
-          return
-        }
-        resolve()
-      })
-    }),
-)
+afterEach(async () => {
+  await app?.close()
+  app = undefined
+})
 
 describe('poi hook server', () => {
   test('runs the deploy hook for GitHub master hook POSTs', async () => {
     const runHook = vi.fn()
-    server = createHookServer({ runHook })
-    const baseUrl = await listen(server)
+    app = createHookApp({ runHook })
 
-    const response = await fetch(`${baseUrl}/api/github-master-hook`, { method: 'POST' })
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/github-master-hook',
+    })
 
-    expect(response.status).toBe(200)
-    expect(await response.text()).toBe('ok')
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toBe('ok')
     expect(runHook).toHaveBeenCalledTimes(1)
   })
 
   test('returns 404 without running the deploy hook for other requests', async () => {
     const runHook = vi.fn()
-    server = createHookServer({ runHook })
-    const baseUrl = await listen(server)
+    app = createHookApp({ runHook })
 
-    const response = await fetch(`${baseUrl}/api/github-master-hook`)
+    const response = await app.inject('/api/github-master-hook')
 
-    expect(response.status).toBe(404)
-    expect(await response.text()).toBe('not found')
-    expect(runHook).not.toHaveBeenCalled()
-  })
-
-  test('returns 400 for malformed request URLs without running the deploy hook', async () => {
-    const runHook = vi.fn()
-    server = createHookServer({ runHook })
-    const baseUrl = await listen(server)
-
-    const socket = await new Promise<Socket>((resolve, reject) => {
-      const client = net.connect(Number(new URL(baseUrl).port), '127.0.0.1')
-      client.once('connect', () => resolve(client))
-      client.once('error', reject)
-    })
-
-    const response = await new Promise<string>((resolve) => {
-      let data = ''
-      socket.on('data', (chunk) => {
-        data += chunk.toString()
-      })
-      socket.on('end', () => resolve(data))
-      socket.end('GET http://% HTTP/1.1\r\nHost: invalid\r\nConnection: close\r\n\r\n')
-    })
-
-    expect(response).toContain('400')
-    expect(response).toContain('bad request')
+    expect(response.statusCode).toBe(404)
+    expect(response.body).toBe('not found')
     expect(runHook).not.toHaveBeenCalled()
   })
 })

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,15 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { type FastifyInstance } from 'fastify'
 
-interface HookModule {
-  createHookApp: (options?: { runHook?: () => void }) => FastifyInstance
-}
-
-const loadHookModule = async (): Promise<HookModule> => {
-  const hookPath = '../hooks.js'
-  const mod = (await import(hookPath)) as { default?: HookModule } & Partial<HookModule>
-  return mod.default ?? (mod as HookModule)
-}
+import { createHookApp } from '../hooks'
 
 let app: FastifyInstance | undefined
 
@@ -20,7 +12,6 @@ afterEach(async () => {
 
 describe('poi hook server', () => {
   test('runs the deploy hook for GitHub master hook POSTs', async () => {
-    const { createHookApp } = await loadHookModule()
     const runHook = vi.fn()
     app = createHookApp({ runHook })
 
@@ -35,7 +26,6 @@ describe('poi hook server', () => {
   })
 
   test('returns 404 without running the deploy hook for other requests', async () => {
-    const { createHookApp } = await loadHookModule()
     const runHook = vi.fn()
     app = createHookApp({ runHook })
 

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -26,7 +26,7 @@ describe('poi hook server', () => {
     })
 
     expect(response.statusCode).toBe(200)
-    expect(response.body).toBe('ok')
+    expect(response.body).toBe('')
     expect(runHook).toHaveBeenCalledTimes(1)
   })
 


### PR DESCRIPTION
## Summary
- replace the poi-hook server's removed Koa dependency with a minimal Fastify app in TypeScript
- start poi-hook with tsx from supervisor
- keep the GitHub master hook endpoint behavior and async deploy trigger
- add Vitest coverage for the hook endpoint and non-matching requests

## Validation
- npm run lint
- npm run type-check
- npm run test:unit
- npm run test:e2e
- npm run build