### PR TITLE
Add OpenCode PR review workflow

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,0 +1,85 @@
+name: OpenCode PR Review
+
+on:
+  pull_request:
+    branches: master
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: opencode-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Review pull request
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      # OpenCode posts its PR summary/session link via issues.createComment.
+      issues: write
+    steps:
+      - name: Check trigger user permissions
+        id: trigger-permission
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRIGGER_USER: ${{ github.actor }}
+        run: |
+          encoded_user=$(jq -nr --arg value "$TRIGGER_USER" '$value|@uri')
+          permission_error=$(mktemp)
+          if ! permission=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${encoded_user}/permission" --jq '.permission' 2>"$permission_error"); then
+            echo "OpenCode permission lookup failed; treating ${TRIGGER_USER} as having no repository permission."
+            sed 's/^/gh api: /' "$permission_error"
+            permission="none"
+          fi
+          rm -f "$permission_error"
+          permission=${permission:-none}
+          echo "permission=${permission}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$permission" == "admin" || "$permission" == "write" ]]; then
+            echo "can_review=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "can_review=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping OpenCode review because ${TRIGGER_USER} has ${permission} repository permission, not write/admin."
+          fi
+
+      - name: Checkout repository
+        if: ${{ steps['trigger-permission'].outputs.can_review == 'true' }}
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run OpenCode review
+        if: ${{ steps['trigger-permission'].outputs.can_review == 'true' }}
+        uses: anomalyco/opencode/github@ed75ce9eccb6d97a4ee0f79d3db8cb33b47b0661
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode-go/deepseek-v4-pro
+          use_github_token: true
+          prompt: |
+            Review this pull request as a senior maintainer.
+
+            During analysis, be adversarial: try to find ways this change could break correctness,
+            security, permissions, reliability, CI behavior, performance, or create concrete long-term maintenance risk.
+
+            Be conservative in what you report. Before reporting a finding, double-check it:
+            - it is caused by this PR
+            - it is reachable or materially risky
+            - it would be worth requesting changes for
+            - it is not already covered by existing review comments, if available
+            - it is not speculative, low-impact, duplicative, or mainly subjective
+
+            Only report high-confidence findings. Prefer no findings over weak findings.
+            Report at most 5 findings, ordered by severity.
+
+            For each finding, include:
+            - the concrete risk
+            - the relevant changed line or behavior
+            - the smallest practical fix
+
+            Do not comment on style, formatting, naming, or preferences unless they create a concrete bug, security issue, or clearly explainable maintenance risk.
+            Do not modify files, commit changes, or push to the pull request branch.


### PR DESCRIPTION
## Summary
- Add an OpenCode PR review workflow for non-draft PRs targeting master
- Gate review execution to write/admin actors before checkout and OpenCode execution
- Use the pinned OpenCode GitHub action with the upstream senior-maintainer review prompt

## Validation
- npm exec --no -- prettier --check .github/workflows/opencode-review.yml