### PR TITLE
ci: pin OpenCode review CLI to 1.17.13

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -57,6 +57,31 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          OPENCODE_CONFIG_CONTENT: |
+            {
+              "$schema": "https://opencode.ai/config.json",
+              "default_agent": "review",
+              "agent": {
+                "review": {
+                  "description": "Read-only pull request reviewer",
+                  "mode": "primary",
+                  "permission": {
+                    "read": "allow",
+                    "glob": "allow",
+                    "grep": "allow",
+                    "list": "allow",
+                    "webfetch": "allow",
+                    "websearch": "allow",
+                    "edit": "deny",
+                    "bash": "deny",
+                    "task": "deny",
+                    "todowrite": "deny",
+                    "question": "deny"
+                  },
+                  "prompt": "Review code only. Do not modify files, create commits, push branches, or make changes. Return review findings as text; the GitHub Action will post your response as a PR comment."
+                }
+              }
+            }
         with:
           model: opencode/hy3-free
           use_github_token: true

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -58,7 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
-          model: opencode-go/hy3-preview-free
+          model: opencode-go/hy3-preview
           use_github_token: true
           prompt: |
             Review this pull request as a senior maintainer.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -58,7 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
-          model: opencode-go/hy3-preview
+          model: opencode/hy3-free
           use_github_token: true
           prompt: |
             Review this pull request as a senior maintainer.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -83,7 +83,7 @@ jobs:
               }
             }
         with:
-          model: opencode/hy3-free
+          model: opencode-go/glm-5.2
           use_github_token: true
           prompt: |
             Review this pull request as a senior maintainer.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -51,16 +51,32 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Cache OpenCode
+        if: ${{ steps['trigger-permission'].outputs.can_review == 'true' }}
+        id: opencode-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.opencode/bin
+          key: opencode-${{ runner.os }}-${{ runner.arch }}-v1.17.13
+
+      - name: Install OpenCode
+        if: ${{ steps['trigger-permission'].outputs.can_review == 'true' && steps.opencode-cache.outputs.cache-hit != 'true' }}
+        env:
+          OPENCODE_CLI_VERSION: 1.17.13
+        run: curl -fsSL https://opencode.ai/install | bash -s -- --version "$OPENCODE_CLI_VERSION" --no-modify-path
+
+      - name: Add OpenCode to PATH
+        if: ${{ steps['trigger-permission'].outputs.can_review == 'true' }}
+        run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
+
       - name: Run OpenCode review
         if: ${{ steps['trigger-permission'].outputs.can_review == 'true' }}
-        uses: anomalyco/opencode/github@ed75ce9eccb6d97a4ee0f79d3db8cb33b47b0661
         env:
           GITHUB_TOKEN: ${{ github.token }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-        with:
-          model: opencode-go/glm-5.2
-          use_github_token: true
-          prompt: |
+          MODEL: opencode-go/glm-5.2
+          USE_GITHUB_TOKEN: true
+          PROMPT: |
             Review this pull request as a senior maintainer.
 
             During analysis, be adversarial: try to find ways this change could break correctness,
@@ -83,3 +99,4 @@ jobs:
 
             Do not comment on style, formatting, naming, or preferences unless they create a concrete bug, security issue, or clearly explainable maintenance risk.
             Do not modify files, commit changes, or push to the pull request branch.
+        run: opencode github run

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -58,7 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
-          model: opencode-go/deepseek-v4-pro
+          model: opencode-go/hy3-preview-free
           use_github_token: true
           prompt: |
             Review this pull request as a senior maintainer.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -57,31 +57,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          OPENCODE_CONFIG_CONTENT: |
-            {
-              "$schema": "https://opencode.ai/config.json",
-              "default_agent": "review",
-              "agent": {
-                "review": {
-                  "description": "Read-only pull request reviewer",
-                  "mode": "primary",
-                  "permission": {
-                    "read": "allow",
-                    "glob": "allow",
-                    "grep": "allow",
-                    "list": "allow",
-                    "webfetch": "allow",
-                    "websearch": "allow",
-                    "edit": "deny",
-                    "bash": "deny",
-                    "task": "deny",
-                    "todowrite": "deny",
-                    "question": "deny"
-                  },
-                  "prompt": "Review code only. Do not modify files, create commits, push branches, or make changes. Return review findings as text; the GitHub Action will post your response as a PR comment."
-                }
-              }
-            }
         with:
           model: opencode-go/glm-5.2
           use_github_token: true


### PR DESCRIPTION
Pin the OpenCode PR review workflow to CLI v1.17.13 while using `opencode-go/glm-5.2`, matching the version/model combination that previously reviewed successfully in website-kai.