### PR TITLE
Wire PostgreSQL migrations into deploy hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,29 @@ The configured database URL selects the persistence backend:
 Set `POI_SERVER_DATABASE_URL`; `POI_SERVER_DB` remains a backward-compatible fallback. PostgreSQL
 startup validates the explicit Drizzle migration version and never runs migrations automatically.
 
+## Deployment hook
+
+`POST /api/github-master-hook` starts the tracked `github-master-hook` deployment script and returns
+without waiting for deployment to finish. The script safely continues from a temporary copy while it:
+
+1. Fetches and checks out `origin/master`.
+2. Installs the repository's configured Node.js version and dependencies.
+3. Runs `npm run db:migrate`.
+4. Prunes development dependencies and restarts the application and hook processes through Supervisor.
+5. Records the deployed commit and deployment time.
+
+`db:migrate` applies pending Drizzle migrations when `POI_SERVER_DATABASE_URL` selects PostgreSQL. It
+performs no database setup for MongoDB, preserving the existing MongoDB deployment flow. A PostgreSQL
+migration failure stops the deployment before the application restarts.
+
+The hook emits timestamped stage logs, previous and target commit IDs, elapsed time, and the failed
+stage and exit code when a command aborts deployment. It does not enable shell tracing or intentionally
+log environment values, credentials, or machine paths.
+
+Keep machine-specific database URLs, credentials, and filesystem layout outside the repository. See
+[`docs/postgresql-deployment.md`](docs/postgresql-deployment.md) for PostgreSQL provisioning and
+operations.
+
 ## Development
 
 Prerequisites:

--- a/docs/postgresql-deployment.md
+++ b/docs/postgresql-deployment.md
@@ -5,7 +5,22 @@ target PostgreSQL 18. Application startup validates the schema but never applies
 
 ## Provisioning
 
-Apply migrations before starting the server:
+The same GitHub master deploy hook supports the separate MongoDB and PostgreSQL machines. Each machine
+runs its own hook against its own checkout and configuration; the hook does not copy credentials or
+database settings between machines.
+
+The hook executes from a temporary copy so updating the tracked script during checkout cannot modify
+the running deployment. It fetches `origin/master`, installs the configured Node.js version and
+dependencies, and runs `npm run db:migrate` before pruning development dependencies or restarting
+Supervisor processes. After a successful restart, it records the deployed commit and deployment time.
+
+`db:migrate` resolves the database URL exactly as application startup does. PostgreSQL deployments apply
+pending Drizzle migrations, while MongoDB deployments perform no database setup and retain their
+existing deployment behavior. Migration failure aborts deployment before the server restarts.
+
+Configure `POI_SERVER_DATABASE_URL` in the PostgreSQL machine's environment or ignored `.env` file.
+Keep the connection URL, credentials, and machine-specific filesystem paths out of tracked files.
+For provisioning or deployment outside the hook, apply migrations before starting the server:
 
 ```powershell
 $env:POI_SERVER_DATABASE_URL = 'postgresql://user:password@host/poi'
@@ -73,6 +88,8 @@ Aggregate, Definition, and Item-improvement Fact tables are retained.
 
 ## Operational checks
 
+- Deploy logs include timestamped stages, previous and target commit IDs, total elapsed time, and the
+  failed stage and exit code. Shell tracing and environment-value logging remain disabled.
 - `/api/status.database` reports the active backend and approximate counts.
 - Monitor validation/database errors, pool active/idle/waiting clients, lock waits, statement
   latency, CPU, and storage latency.

--- a/github-master-hook
+++ b/github-master-hook
@@ -1,7 +1,5 @@
 #!/bin/bash
-set -euo pipefail
-
-cd /srv/poi
+set -Eeuo pipefail
 
 if [ "${POI_DEPLOY_FROM_TEMP:-0}" != "1" ]; then
   temp_script="$(mktemp /tmp/poi-server-deploy.XXXXXX)"
@@ -19,31 +17,103 @@ FNM_BIN="${FNM_BIN:-/srv/poi/.fnm-bin/fnm}"
 BOOTSTRAP_FNM_BIN="${BOOTSTRAP_FNM_BIN:-/home/poi/.local/share/fnm/fnm}"
 DEPLOY_STATE="${DEPLOY_STATE:-/srv/poi/.deploy-state}"
 
+deploy_started_epoch="$(date +%s)"
+deploy_stage="bootstrap"
+
+log_deploy() {
+  printf '[poi-deploy] timestamp=%s stage=%s %s\n' \
+    "$(date --iso-8601=seconds)" "$deploy_stage" "$*"
+}
+
+fail_deploy() {
+  local exit_code="$1"
+  local elapsed_seconds=$(( $(date +%s) - deploy_started_epoch ))
+  log_deploy "status=failed exit_code=$exit_code elapsed_seconds=$elapsed_seconds"
+  exit "$exit_code"
+}
+
+on_deploy_error() {
+  fail_deploy "$?"
+}
+
+trap on_deploy_error ERR
+log_deploy "status=started"
+
+deploy_stage="enter-application-directory"
+log_deploy "status=running"
+if ! cd /srv/poi 2>/dev/null; then
+  fail_deploy 1
+fi
+
+deploy_stage="bootstrap"
 mkdir -p "$(dirname "$FNM_BIN")" "$FNM_DIR"
 if [ -x "$BOOTSTRAP_FNM_BIN" ]; then
   install -m 755 "$BOOTSTRAP_FNM_BIN" "$FNM_BIN"
 elif [ ! -x "$FNM_BIN" ]; then
-  echo "fnm is required but was not found at $FNM_BIN or $BOOTSTRAP_FNM_BIN" >&2
-  exit 127
+  echo "fnm is required but no executable deployment runtime was found" >&2
+  fail_deploy 127
 fi
 
+deploy_stage="fetch"
 previous_sha="$(git rev-parse HEAD)"
+log_deploy "status=running previous_sha=$previous_sha"
 git fetch origin
-supervisorctl stop poi || true
+target_sha="$(git rev-parse origin/master)"
+log_deploy "status=fetched target_sha=$target_sha"
+
+deploy_stage="stop-application"
+log_deploy "status=running"
+if ! supervisorctl stop poi; then
+  log_deploy "status=warning result=nonzero-exit-ignored"
+fi
+
+deploy_stage="checkout"
+log_deploy "status=running target_sha=$target_sha"
 git checkout master
 git reset --hard origin/master
+
+deploy_stage="install-runtime"
+log_deploy "status=running"
 "$FNM_BIN" install
+
+deploy_stage="install-dependencies"
+log_deploy "status=running"
 "$FNM_BIN" exec --using .node-version npm ci
 
+deploy_stage="migrate-database"
+log_deploy "status=running"
+"$FNM_BIN" exec --using .node-version npm run db:migrate
+
+deploy_stage="prune-dependencies"
+log_deploy "status=running"
 "$FNM_BIN" exec --using .node-version npm prune --omit=dev
+
+deploy_stage="reload-supervisor"
+log_deploy "status=running"
 supervisorctl reread
 supervisorctl update
-supervisorctl stop poi || true
+
+deploy_stage="restart-application"
+log_deploy "status=running"
+if ! supervisorctl stop poi; then
+  log_deploy "status=warning result=nonzero-exit-ignored"
+fi
 supervisorctl start poi
+
+deploy_stage="restart-hook"
+log_deploy "status=running"
 supervisorctl restart poi-hook
 
+deploy_stage="record-state"
+deployed_sha="$(git rev-parse HEAD)"
+log_deploy "status=running sha=$deployed_sha"
 {
   echo "previous_sha=$previous_sha"
-  echo "sha=$(git rev-parse HEAD)"
+  echo "sha=$deployed_sha"
   echo "deployed_at=$(date --iso-8601=seconds)"
 } >"$DEPLOY_STATE"
+
+deploy_stage="complete"
+elapsed_seconds=$(( $(date +%s) - deploy_started_epoch ))
+log_deploy \
+  "status=succeeded previous_sha=$previous_sha sha=$deployed_sha elapsed_seconds=$elapsed_seconds"

--- a/scripts/postgres-migrate.ts
+++ b/scripts/postgres-migrate.ts
@@ -2,9 +2,17 @@ import 'dotenv/config'
 import path from 'path'
 
 import { config } from '../src/config'
-import { migratePostgres } from '../src/db/postgres/migrations'
+import { migrateDatabase } from '../src/db/postgres/migrations'
 
-void migratePostgres(config.db, path.resolve(config.root, '../drizzle')).catch((error) => {
-  console.error(error)
-  process.exitCode = 1
-})
+void migrateDatabase(config.db, path.resolve(config.root, '../drizzle'))
+  .then((backend) => {
+    if (backend === 'postgresql') {
+      console.log('PostgreSQL migrations completed')
+    } else {
+      console.log('MongoDB requires no database migrations')
+    }
+  })
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })

--- a/scripts/postgres-migrate.ts
+++ b/scripts/postgres-migrate.ts
@@ -2,16 +2,8 @@ import 'dotenv/config'
 import path from 'path'
 
 import { config } from '../src/config'
+import { formatMigrationError } from '../src/db/postgres/migration-error'
 import { migrateDatabase } from '../src/db/postgres/migrations'
-
-export const formatMigrationError = (error: unknown, redactedValues: readonly string[]): string => {
-  const message = error instanceof Error ? error.message : String(error)
-  return redactedValues.reduce(
-    (sanitized, value) =>
-      value.length === 0 ? sanitized : sanitized.split(value).join('<redacted>'),
-    message,
-  )
-}
 
 if (require.main === module) {
   const migrationsFolder = path.resolve(config.root, '../drizzle')

--- a/scripts/postgres-migrate.ts
+++ b/scripts/postgres-migrate.ts
@@ -4,15 +4,28 @@ import path from 'path'
 import { config } from '../src/config'
 import { migrateDatabase } from '../src/db/postgres/migrations'
 
-void migrateDatabase(config.db, path.resolve(config.root, '../drizzle'))
-  .then((backend) => {
-    if (backend === 'postgresql') {
-      console.log('PostgreSQL migrations completed')
-    } else {
-      console.log('MongoDB requires no database migrations')
-    }
-  })
-  .catch((error) => {
-    console.error(error)
-    process.exitCode = 1
-  })
+export const formatMigrationError = (error: unknown, redactedValues: readonly string[]): string => {
+  const message = error instanceof Error ? error.message : String(error)
+  return redactedValues.reduce(
+    (sanitized, value) =>
+      value.length === 0 ? sanitized : sanitized.split(value).join('<redacted>'),
+    message,
+  )
+}
+
+if (require.main === module) {
+  const migrationsFolder = path.resolve(config.root, '../drizzle')
+
+  void migrateDatabase(config.db, migrationsFolder)
+    .then((backend) => {
+      if (backend === 'postgresql') {
+        console.log('PostgreSQL migrations completed')
+      } else {
+        console.log('MongoDB requires no database migrations')
+      }
+    })
+    .catch((error) => {
+      console.error(formatMigrationError(error, [config.root, migrationsFolder, config.db]))
+      process.exitCode = 1
+    })
+}

--- a/scripts/postgres-migrate.ts
+++ b/scripts/postgres-migrate.ts
@@ -5,19 +5,17 @@ import { config } from '../src/config'
 import { formatMigrationError } from '../src/db/postgres/migration-error'
 import { migrateDatabase } from '../src/db/postgres/migrations'
 
-if (require.main === module) {
-  const migrationsFolder = path.resolve(config.root, '../drizzle')
+const migrationsFolder = path.resolve(config.root, '../drizzle')
 
-  void migrateDatabase(config.db, migrationsFolder)
-    .then((backend) => {
-      if (backend === 'postgresql') {
-        console.log('PostgreSQL migrations completed')
-      } else {
-        console.log('MongoDB requires no database migrations')
-      }
-    })
-    .catch((error) => {
-      console.error(formatMigrationError(error, [config.root, migrationsFolder, config.db]))
-      process.exitCode = 1
-    })
-}
+void migrateDatabase(config.db, migrationsFolder)
+  .then((backend) => {
+    if (backend === 'postgresql') {
+      console.log('PostgreSQL migrations completed')
+    } else {
+      console.log('MongoDB requires no database migrations')
+    }
+  })
+  .catch((error) => {
+    console.error(formatMigrationError(error, [config.root, migrationsFolder, config.db]))
+    process.exitCode = 1
+  })

--- a/src/db/postgres/migration-error.ts
+++ b/src/db/postgres/migration-error.ts
@@ -1,0 +1,8 @@
+export const formatMigrationError = (error: unknown, redactedValues: readonly string[]): string => {
+  const message = error instanceof Error ? error.message : String(error)
+  return redactedValues.reduce(
+    (sanitized, value) =>
+      value.length === 0 ? sanitized : sanitized.split(value).join('<redacted>'),
+    message,
+  )
+}

--- a/src/db/postgres/migrations.ts
+++ b/src/db/postgres/migrations.ts
@@ -4,13 +4,12 @@ import { Pool } from 'pg'
 
 import { resolveDatabaseBackend } from '../backend'
 
-export const migratePostgres = async (
+type ApplyPostgresMigrations = (databaseUrl: string, migrationsFolder: string) => Promise<void>
+
+const applyPostgresMigrations: ApplyPostgresMigrations = async (
   databaseUrl: string,
   migrationsFolder: string,
 ): Promise<void> => {
-  if (resolveDatabaseBackend(databaseUrl) !== 'postgresql') {
-    throw new Error('PostgreSQL migrations require a postgres: or postgresql: database URL')
-  }
   const pool = new Pool({
     connectionString: databaseUrl,
     connectionTimeoutMillis: 5000,
@@ -21,4 +20,18 @@ export const migratePostgres = async (
   } finally {
     await pool.end()
   }
+}
+
+export const migrateDatabase = async (
+  databaseUrl: string,
+  migrationsFolder: string,
+  applyPostgres: ApplyPostgresMigrations = applyPostgresMigrations,
+) => {
+  const backend = resolveDatabaseBackend(databaseUrl)
+  if (backend === 'mongodb') {
+    return backend
+  }
+
+  await applyPostgres(databaseUrl, migrationsFolder)
+  return backend
 }

--- a/tests/database-migrations.test.ts
+++ b/tests/database-migrations.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
 
+import { formatMigrationError } from '../scripts/postgres-migrate'
 import { migrateDatabase } from '../src/db/postgres/migrations'
 
 describe('database migrations', () => {
@@ -30,5 +31,14 @@ describe('database migrations', () => {
     await expect(
       migrateDatabase('postgresql://localhost/poi', '/drizzle', applyPostgresMigrations),
     ).rejects.toThrow('migration failed')
+  })
+
+  test('formats migration failures without stack traces or sensitive values', () => {
+    const error = new Error('Failed under application-root-token using database-url-token')
+    error.stack = `${error.message}\n    at hidden-stack-location`
+
+    expect(formatMigrationError(error, ['application-root-token', 'database-url-token'])).toBe(
+      'Failed under <redacted> using <redacted>',
+    )
   })
 })

--- a/tests/database-migrations.test.ts
+++ b/tests/database-migrations.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
 
-import { formatMigrationError } from '../scripts/postgres-migrate'
+import { formatMigrationError } from '../src/db/postgres/migration-error'
 import { migrateDatabase } from '../src/db/postgres/migrations'
 
 describe('database migrations', () => {

--- a/tests/database-migrations.test.ts
+++ b/tests/database-migrations.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { migrateDatabase } from '../src/db/postgres/migrations'
+
+describe('database migrations', () => {
+  test('leaves MongoDB unchanged', async () => {
+    const applyPostgresMigrations = vi.fn()
+
+    await expect(
+      migrateDatabase('mongodb://localhost/poi', '/drizzle', applyPostgresMigrations),
+    ).resolves.toBe('mongodb')
+    expect(applyPostgresMigrations).not.toHaveBeenCalled()
+  })
+
+  test.each(['postgres://localhost/poi', 'postgresql://localhost/poi'])(
+    'applies PostgreSQL migrations for %s',
+    async (databaseUrl) => {
+      const applyPostgresMigrations = vi.fn().mockResolvedValue(undefined)
+
+      await expect(migrateDatabase(databaseUrl, '/drizzle', applyPostgresMigrations)).resolves.toBe(
+        'postgresql',
+      )
+      expect(applyPostgresMigrations).toHaveBeenCalledWith(databaseUrl, '/drizzle')
+    },
+  )
+
+  test('does not hide PostgreSQL migration failures', async () => {
+    const applyPostgresMigrations = vi.fn().mockRejectedValue(new Error('migration failed'))
+
+    await expect(
+      migrateDatabase('postgresql://localhost/poi', '/drizzle', applyPostgresMigrations),
+    ).rejects.toThrow('migration failed')
+  })
+})

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import ChildProcess from 'child_process'
+import fs from 'fs'
 import { type FastifyInstance } from 'fastify'
 import path from 'path'
 import { EventEmitter } from 'events'
@@ -53,5 +54,29 @@ describe('poi hook server', () => {
       { stdio: 'inherit' },
     )
     expect(path.isAbsolute(spawn.mock.calls[0][0] as string)).toBe(true)
+  })
+
+  test('prepares the selected database before pruning dependencies and restarting', () => {
+    const hook = fs.readFileSync(path.resolve(__dirname, '../github-master-hook'), 'utf8')
+    const installIndex = hook.indexOf('npm ci')
+    const databaseMigrationIndex = hook.indexOf('npm run db:migrate')
+    const pruneIndex = hook.indexOf('npm prune --omit=dev')
+    const restartIndex = hook.indexOf('supervisorctl start poi')
+
+    expect(installIndex).toBeGreaterThan(-1)
+    expect(databaseMigrationIndex).toBeGreaterThan(installIndex)
+    expect(pruneIndex).toBeGreaterThan(databaseMigrationIndex)
+    expect(restartIndex).toBeGreaterThan(pruneIndex)
+  })
+
+  test('logs deploy stages and failure context without shell tracing', () => {
+    const hook = fs.readFileSync(path.resolve(__dirname, '../github-master-hook'), 'utf8')
+
+    expect(hook).toContain('trap on_deploy_error ERR')
+    expect(hook).toContain('status=failed exit_code=$exit_code elapsed_seconds=$elapsed_seconds')
+    expect(hook).toContain('status=succeeded previous_sha=$previous_sha sha=$deployed_sha')
+    expect(hook).toContain('deploy_stage="migrate-database"')
+    expect(hook).toContain('deploy_stage="restart-application"')
+    expect(hook).not.toMatch(/\bset -x\b/)
   })
 })

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import ChildProcess from 'child_process'
-import fs from 'fs'
+import { readFileSync } from 'fs'
 import { type FastifyInstance } from 'fastify'
 import path from 'path'
 import { EventEmitter } from 'events'
@@ -57,7 +57,7 @@ describe('poi hook server', () => {
   })
 
   test('prepares the selected database before pruning dependencies and restarting', () => {
-    const hook = fs.readFileSync(path.resolve(__dirname, '../github-master-hook'), 'utf8')
+    const hook = readFileSync(path.resolve(__dirname, '../github-master-hook'), 'utf8')
     const installIndex = hook.indexOf('npm ci')
     const databaseMigrationIndex = hook.indexOf('npm run db:migrate')
     const pruneIndex = hook.indexOf('npm prune --omit=dev')
@@ -70,7 +70,7 @@ describe('poi hook server', () => {
   })
 
   test('logs deploy stages and failure context without shell tracing', () => {
-    const hook = fs.readFileSync(path.resolve(__dirname, '../github-master-hook'), 'utf8')
+    const hook = readFileSync(path.resolve(__dirname, '../github-master-hook'), 'utf8')
 
     expect(hook).toContain('trap on_deploy_error ERR')
     expect(hook).toContain('status=failed exit_code=$exit_code elapsed_seconds=$elapsed_seconds')


### PR DESCRIPTION
## Summary
- run the shared `db:migrate` command from the deploy hook after dependency installation and before pruning or service restart
- make `db:migrate` apply Drizzle migrations for PostgreSQL and explicitly no-op for MongoDB
- abort deployment on migration failure while preserving the existing MongoDB deployment path
- add timestamped deployment stages, commit IDs, elapsed time, warnings, and failed-stage exit codes without shell tracing
- sanitize migration failures to exclude stack traces, configured database URLs, and machine-specific paths
- keep reusable migration error formatting in a side-effect-free module
- document the deployment-hook lifecycle and PostgreSQL provisioning without exposing machine filesystem paths
- add regression coverage for backend-aware migrations, hook ordering, safe diagnostics, and error redaction

## Validation
- `npm run test:unit`
- `npm run type-check`
- `npm run lint -- --quiet`
- `bash -n github-master-hook`
- MongoDB `npm run db:migrate` no-op execution

## Review
- CI passes
- all Copilot review threads are resolved
- latest Copilot review generated no new comments