### PR TITLE
Automate monthly Community Dump maintenance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,8 +23,8 @@ NODE_ENV=development
 # POI_SERVER_DATABASE_URL=postgresql://user:password@localhost:5432/poi-development
 
 # Cloudflare R2 (or any S3-compatible) object-store configuration for the Community Dump
-# publish/cleanup CLI commands (db:dumps:publish, db:dumps:cleanup). All four are required
-# whenever those commands run; there is no default bucket or endpoint.
+# publish/cleanup CLI commands (db:dumps:publish, db:dumps:cleanup, db:dumps:maintain).
+# All four are required whenever those commands run; there is no default bucket or endpoint.
 # POI_SERVER_DUMP_R2_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
 # POI_SERVER_DUMP_R2_BUCKET=community-dumps
 # SECRET: never commit a real value.
@@ -41,3 +41,4 @@ NODE_ENV=development
 # postgresql:// URL, and all four POI_SERVER_DUMP_R2_* variables above to be set):
 #   npm run db:dumps:publish -- 2024-01
 #   npm run db:dumps:cleanup -- 42
+#   npm run db:dumps:maintain

--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,5 @@ NODE_ENV=development
 #   npm run db:dumps:publish -- 2024-01
 #   npm run db:dumps:cleanup -- 42
 #   npm run db:dumps:maintain
+# R2-only credential/bucket preflight; does not require POI_SERVER_DATABASE_URL:
+#   npm run db:dumps:r2-check

--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,9 @@ NODE_ENV=development
 # SECRET: contains the database password; never commit a real value.
 # POI_SERVER_DATABASE_URL=postgresql://user:password@localhost:5432/poi-development
 
-# Cloudflare R2 (or any S3-compatible) object-store configuration for the Community Dump
-# publish/cleanup CLI commands (db:dumps:publish, db:dumps:cleanup, db:dumps:maintain).
-# All four are required whenever those commands run; there is no default bucket or endpoint.
+# Cloudflare R2 (or any S3-compatible) object-store configuration for Community Dump publication
+# and cleanup (db:dumps:publish, db:dumps:cleanup, and the publish/cleanup phases of
+# db:dumps:maintain). All four are required for those phases; there is no default bucket or endpoint.
 # POI_SERVER_DUMP_R2_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
 # POI_SERVER_DUMP_R2_BUCKET=community-dumps
 # SECRET: never commit a real value.

--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,4 @@
 .gitignore text eol=lf
 github-master-hook text eol=lf
 fnm-exec text eol=lf
-run-monthly-dump-maintenance text eol=lf
-setup-monthly-dump-cron text eol=lf
 supervisior.conf text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -14,4 +14,6 @@
 .gitignore text eol=lf
 github-master-hook text eol=lf
 fnm-exec text eol=lf
+run-monthly-dump-maintenance text eol=lf
+setup-monthly-dump-cron text eol=lf
 supervisior.conf text eol=lf

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,6 +13,10 @@ _Avoid_: Report record
 A single accepted report retained independently rather than combined with prior reports.
 _Avoid_: Append-only report, report record
 
+**Observation Dataset**:
+A named kind of Observation whose Reports share the same meaning and Community Dump shape.
+_Avoid_: Partition, record type
+
 **Current State**:
 The most recently accepted value for a stable identity, replacing the previously known value.
 _Avoid_: Aggregate

--- a/README.md
+++ b/README.md
@@ -61,4 +61,6 @@ Setup:
 
 Validation commands are `npm test`, `npm run type-check`, and `npm run lint`. PostgreSQL deployment,
 partition maintenance, and Community Dump commands are documented in
-[`docs/postgresql-deployment.md`](docs/postgresql-deployment.md).
+[`docs/postgresql-deployment.md`](docs/postgresql-deployment.md). The current persisted report
+datasets and their retention classifications are listed in
+[`docs/report-data.md`](docs/report-data.md).

--- a/docs/postgresql-deployment.md
+++ b/docs/postgresql-deployment.md
@@ -70,9 +70,42 @@ classifications.
 
 ## Community Dumps
 
-Configure `POI_SERVER_DUMP_R2_ENDPOINT`, `POI_SERVER_DUMP_R2_BUCKET`,
-`POI_SERVER_DUMP_R2_ACCESS_KEY_ID`, and `POI_SERVER_DUMP_R2_SECRET_ACCESS_KEY`. Optional settings are
-`POI_SERVER_DUMP_R2_REGION` and `POI_SERVER_DUMP_R2_FORCE_PATH_STYLE`.
+### Cloudflare R2 credentials
+
+Community Dump publication uses Cloudflare R2's S3-compatible API. It requires R2 S3 credentials, not
+a general Cloudflare API token:
+
+1. Create or select the target R2 bucket.
+2. In the R2 API Tokens page, create a user or account API token with **Object Read & Write**
+   permission, scoped to that bucket only.
+3. Save the generated Access Key ID and Secret Access Key when Cloudflare displays them. The secret
+   is shown only once.
+4. Put the credentials and bucket configuration in the deployment machine's ignored `.env` file:
+
+```dotenv
+POI_SERVER_DUMP_R2_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+POI_SERVER_DUMP_R2_BUCKET=<bucket-name>
+POI_SERVER_DUMP_R2_ACCESS_KEY_ID=<access-key-id>
+POI_SERVER_DUMP_R2_SECRET_ACCESS_KEY=<secret-access-key>
+POI_SERVER_DUMP_R2_REGION=auto
+POI_SERVER_DUMP_R2_FORCE_PATH_STYLE=true
+```
+
+Use the endpoint shown for the bucket in Cloudflare if it differs from the standard account endpoint.
+See Cloudflare's [R2 authentication](https://developers.cloudflare.com/r2/api/tokens/) and
+[S3 API](https://developers.cloudflare.com/r2/get-started/s3/) documentation.
+
+Both read and write access are required: publication uploads each immutable object and immediately
+reads it back to verify its byte count and SHA-256; cleanup later reads every object again before
+dropping database partitions.
+
+The cron installer does not create, copy, or print credentials. The maintenance TypeScript entrypoint
+loads the ignored `.env` file at runtime under the configured service user. Keep the file readable
+only by the deployment and service accounts, and never commit these values or store them in CI.
+
+The four endpoint, bucket, access-key, and secret-key variables are required.
+`POI_SERVER_DUMP_R2_REGION` and `POI_SERVER_DUMP_R2_FORCE_PATH_STYLE` are optional and default to
+`auto` and `true`.
 
 Publish a closed JST Dump Month:
 

--- a/docs/postgresql-deployment.md
+++ b/docs/postgresql-deployment.md
@@ -157,6 +157,10 @@ publication or eligible cleanup, and one failed cleanup does not prevent later c
 attempted. Any failure produces a nonzero exit after all possible work has completed. A successful
 run prints a JSON summary.
 
+R2 initialization happens after the database-only partition phase. Missing or invalid R2
+configuration is reported as a maintenance failure and skips publication and cleanup, but it does not
+prevent creation of the upcoming partitions.
+
 The command loads the database and R2 settings from the process environment and the ignored `.env`
 file. It refuses non-PostgreSQL database URLs.
 

--- a/docs/postgresql-deployment.md
+++ b/docs/postgresql-deployment.md
@@ -131,11 +131,11 @@ that Dump Month. Current State, Aggregate, Definition, and Item-improvement Fact
 
 Automated maintenance has three layers:
 
-| Entry point                    | Purpose                                                              |
-| ------------------------------ | -------------------------------------------------------------------- |
-| `npm run db:dumps:maintain`    | Runs the TypeScript maintenance command directly.                    |
-| `run-monthly-dump-maintenance` | Adds locking, timeout enforcement, and timestamped operational logs. |
-| `setup-monthly-dump-cron`      | Installs or updates the managed crontab entry.                       |
+| Entry point                       | Purpose                                                              |
+| --------------------------------- | -------------------------------------------------------------------- |
+| `npm run db:dumps:maintain`       | Runs the TypeScript maintenance command directly.                    |
+| `run-monthly-dump-maintenance.sh` | Adds locking, timeout enforcement, and timestamped operational logs. |
+| `setup-monthly-dump-cron.sh`      | Installs or updates the managed crontab entry.                       |
 
 #### Maintenance command
 
@@ -165,7 +165,7 @@ file. It refuses non-PostgreSQL database URLs.
 Run the operational wrapper as the service user:
 
 ```bash
-./run-monthly-dump-maintenance
+./run-monthly-dump-maintenance.sh
 ```
 
 The runner:
@@ -190,11 +190,11 @@ cron implementation supporting `CRON_TZ`. Run it as root from the application ch
 sudo env \
   POI_DUMP_CRON_APP_DIR=<application-directory> \
   POI_DUMP_CRON_USER=<service-user> \
-  ./setup-monthly-dump-cron
+  ./setup-monthly-dump-cron.sh
 ```
 
-The application checkout, `run-monthly-dump-maintenance`, `fnm-exec`, and ignored `.env` file must be
-readable by the selected service user. The installer:
+The application checkout, `run-monthly-dump-maintenance.sh`, `fnm-exec`, and ignored `.env` file must
+be readable by the selected service user. The installer:
 
 1. Validates the user, five-field schedule, paths, timeout, and required executables.
 2. Creates the log and lock files with service-user ownership.

--- a/docs/postgresql-deployment.md
+++ b/docs/postgresql-deployment.md
@@ -107,6 +107,19 @@ The four endpoint, bucket, access-key, and secret-key variables are required.
 `POI_SERVER_DUMP_R2_REGION` and `POI_SERVER_DUMP_R2_FORCE_PATH_STYLE` are optional and default to
 `auto` and `true`.
 
+Verify the complete credential and bucket lifecycle before enabling cron:
+
+```bash
+npm run db:dumps:r2-check
+```
+
+The preflight creates one unique temporary object under
+`healthchecks/poi-server/r2-connection/`, reads it back, verifies the exact bytes, and deletes it
+before returning success. It does not connect to PostgreSQL. A failure verifies that the configured
+endpoint, bucket, credentials, or Object Read & Write permissions need attention. If verification
+succeeds but deletion fails, the command fails and reports the temporary object key for manual
+cleanup.
+
 Publish a closed JST Dump Month:
 
 ```powershell
@@ -116,6 +129,29 @@ npm run db:dumps:publish -- 2026-07
 The command streams and verifies the target month's partition for every registered Observation
 dataset, uploads immutable data objects, then uploads the verified manifest as the publication commit
 point. It is safe to retry and never overwrites an existing object.
+
+The dedicated dump bucket uses one root-level folder per JST Dump Month:
+
+```text
+/
+├── legacy/
+├── healthchecks/
+└── 2026-07/
+    ├── manifest.json
+    ├── createShipObservations.jsonl.zst
+    ├── createItemObservations.jsonl.zst
+    ├── remodelItemObservations.jsonl.zst
+    ├── dropShipObservations.jsonl.zst
+    ├── passEventObservations.jsonl.zst
+    ├── battleApiObservations.jsonl.zst
+    ├── nightContactObservations.jsonl.zst
+    ├── aaciObservations.jsonl.zst
+    └── nightBattleCiObservations.jsonl.zst
+```
+
+Each Dump Month has one canonical immutable publication. Its `manifest.json` records the schema
+version, file keys, row counts, compressed sizes, and SHA-256 digests. Existing root-level and
+`legacy/` objects are not moved or deleted by the PostgreSQL publisher.
 
 After the seven-day grace period, clean one exact run ID:
 

--- a/docs/postgresql-deployment.md
+++ b/docs/postgresql-deployment.md
@@ -182,8 +182,8 @@ The runner:
 - delegates Node.js selection to `fnm-exec`.
 
 `POI_DUMP_CRON_APP_DIR`, `POI_DUMP_CRON_LOCK_FILE`, and `POI_DUMP_CRON_TIMEOUT` may be set when
-running the wrapper manually; direct invocations use GNU `timeout` duration syntax. The installer
-accepts positive integers followed by `s`, `m`, `h`, or `d`, such as `90m` or `12h`.
+running the wrapper manually. Both the runner and installer accept a positive integer followed by one
+of `s`, `m`, `h`, or `d`, such as `90m` or `12h`.
 
 #### Cron installer
 

--- a/docs/postgresql-deployment.md
+++ b/docs/postgresql-deployment.md
@@ -45,7 +45,8 @@ rehearsed backup/restore procedure.
 
 ## Monthly partitions
 
-Create all nine upcoming Observation partitions before the month boundary:
+Create the upcoming monthly partition for every registered Observation dataset before the month
+boundary:
 
 ```powershell
 npm run db:partitions:create-upcoming -- 2026-08
@@ -60,6 +61,13 @@ npm run db:partitions:repair -- create_ship_records 2026-08
 
 Both commands are idempotent and reject catalog or boundary mismatches.
 
+Each registered dataset has a separate PostgreSQL parent table, so one target month needs one child
+partition per dataset. There are currently nine registered Observation datasets, which means the
+command currently creates nine child partitions **for the same month**. This is not nine months of
+partitions, and the count should be expected to follow the Community Dump registry if datasets are
+added or removed. See the [report data catalog](report-data.md) for the current datasets and their
+classifications.
+
 ## Community Dumps
 
 Configure `POI_SERVER_DUMP_R2_ENDPOINT`, `POI_SERVER_DUMP_R2_BUCKET`,
@@ -72,9 +80,9 @@ Publish a closed JST Dump Month:
 npm run db:dumps:publish -- 2026-07
 ```
 
-The command streams and verifies all nine partitions, uploads immutable data objects, then uploads
-the verified manifest as the publication commit point. It is safe to retry and never overwrites an
-existing object.
+The command streams and verifies the target month's partition for every registered Observation
+dataset, uploads immutable data objects, then uploads the verified manifest as the publication commit
+point. It is safe to retry and never overwrites an existing object.
 
 After the seven-day grace period, clean one exact run ID:
 
@@ -83,8 +91,107 @@ npm run db:dumps:cleanup -- 42
 ```
 
 Cleanup re-verifies the manifest, every data object, metadata, and partition bounds before
-transactionally detaching and dropping exactly nine Observation partitions. Current State,
-Aggregate, Definition, and Item-improvement Fact tables are retained.
+transactionally detaching and dropping the complete registered set of Observation partitions for
+that Dump Month. Current State, Aggregate, Definition, and Item-improvement Fact tables are retained.
+
+### Scheduled maintenance
+
+Automated maintenance has three layers:
+
+| Entry point                    | Purpose                                                              |
+| ------------------------------ | -------------------------------------------------------------------- |
+| `npm run db:dumps:maintain`    | Runs the TypeScript maintenance command directly.                    |
+| `run-monthly-dump-maintenance` | Adds locking, timeout enforcement, and timestamped operational logs. |
+| `setup-monthly-dump-cron`      | Installs or updates the managed crontab entry.                       |
+
+#### Maintenance command
+
+Run the underlying command manually from the application checkout:
+
+```bash
+npm run db:dumps:maintain
+```
+
+The command derives calendar months from the current JST date and:
+
+1. Creates one partition for each registered Observation dataset for the next JST Dump Month.
+2. Idempotently publishes the previous, fully closed Dump Month.
+3. Finds cleanup candidates using the PostgreSQL clock and cleans every run whose seven-day grace
+   period has elapsed.
+
+The three phases are attempted independently. A partition-creation failure does not prevent
+publication or eligible cleanup, and one failed cleanup does not prevent later candidates from being
+attempted. Any failure produces a nonzero exit after all possible work has completed. A successful
+run prints a JSON summary.
+
+The command loads the database and R2 settings from the process environment and the ignored `.env`
+file. It refuses non-PostgreSQL database URLs.
+
+#### Maintenance runner
+
+Run the operational wrapper as the service user:
+
+```bash
+./run-monthly-dump-maintenance
+```
+
+The runner:
+
+- takes a non-blocking `flock`; an overlapping invocation logs `status=skipped reason=overlap` and
+  exits successfully;
+- terminates maintenance after the configured timeout so a hung process cannot block future runs;
+- logs start, success, failure, exit code, and elapsed time without shell tracing or environment
+  values;
+- delegates Node.js selection to `fnm-exec`.
+
+`POI_DUMP_CRON_APP_DIR`, `POI_DUMP_CRON_LOCK_FILE`, and `POI_DUMP_CRON_TIMEOUT` may be set when
+running the wrapper manually; direct invocations use GNU `timeout` duration syntax. The installer
+accepts positive integers followed by `s`, `m`, `h`, or `d`, such as `90m` or `12h`.
+
+#### Cron installer
+
+The installer requires Linux, Bash, `crontab`, GNU `date`, GNU `timeout`, util-linux `flock`, and a
+cron implementation supporting `CRON_TZ`. Run it as root from the application checkout:
+
+```bash
+sudo env \
+  POI_DUMP_CRON_APP_DIR=<application-directory> \
+  POI_DUMP_CRON_USER=<service-user> \
+  ./setup-monthly-dump-cron
+```
+
+The application checkout, `run-monthly-dump-maintenance`, `fnm-exec`, and ignored `.env` file must be
+readable by the selected service user. The installer:
+
+1. Validates the user, five-field schedule, paths, timeout, and required executables.
+2. Creates the log and lock files with service-user ownership.
+3. Reads the selected user's existing crontab.
+4. Preserves all unrelated entries and replaces only the block between
+   `# BEGIN poi-server monthly dump` and `# END poi-server monthly dump`.
+5. Rejects malformed or duplicated managed markers instead of discarding surrounding entries.
+
+Re-running the installer is the supported way to change the schedule or paths. By default the job
+runs daily at 00:30 JST. Daily execution provides automatic retries while the publish and cleanup
+workflows remain idempotent.
+
+| Variable                  | Meaning                                                            | Default                     |
+| ------------------------- | ------------------------------------------------------------------ | --------------------------- |
+| `POI_DUMP_CRON_APP_DIR`   | Application checkout containing both shell scripts and `fnm-exec`. | Built-in deployment default |
+| `POI_DUMP_CRON_USER`      | User whose crontab runs maintenance.                               | `poi`                       |
+| `POI_DUMP_CRON_SCHEDULE`  | Five-field cron expression interpreted in `Asia/Tokyo`.            | `30 0 * * *`                |
+| `POI_DUMP_CRON_LOG_FILE`  | Combined runner and maintenance output.                            | Built-in log location       |
+| `POI_DUMP_CRON_LOCK_FILE` | File used by `flock` to prevent overlap.                           | Built-in lock location      |
+| `POI_DUMP_CRON_TIMEOUT`   | Maximum duration accepted by GNU `timeout`.                        | `12h`                       |
+
+Verify the installed entry and inspect its output:
+
+```bash
+sudo crontab -u <service-user> -l
+sudo tail -n 100 <log-file>
+```
+
+To disable automation, remove the complete managed marker block from the selected user's crontab.
+Removing the block does not delete published objects, database metadata, logs, or lock files.
 
 ## Operational checks
 

--- a/docs/postgresql-deployment.md
+++ b/docs/postgresql-deployment.md
@@ -256,6 +256,8 @@ workflows remain idempotent.
 | `POI_DUMP_CRON_LOCK_FILE` | File used by `flock` to prevent overlap.                           | Built-in lock location      |
 | `POI_DUMP_CRON_TIMEOUT`   | Maximum duration accepted by GNU `timeout`.                        | `12h`                       |
 
+Application, log, and lock path overrides must be absolute POSIX paths.
+
 Verify the installed entry and inspect its output:
 
 ```bash

--- a/docs/postgresql-migration-plan.md
+++ b/docs/postgresql-migration-plan.md
@@ -41,12 +41,12 @@ const databaseUrl = process.env.POI_SERVER_DATABASE_URL ?? process.env.POI_SERVE
 
 Backend selection maps URI schemes as follows:
 
-| URI scheme | Backend |
-| --- | --- |
-| `mongodb:` | MongoDB |
-| `mongodb+srv:` | MongoDB |
-| `postgres:` | PostgreSQL |
-| `postgresql:` | PostgreSQL |
+| URI scheme     | Backend    |
+| -------------- | ---------- |
+| `mongodb:`     | MongoDB    |
+| `mongodb+srv:` | MongoDB    |
+| `postgres:`    | PostgreSQL |
+| `postgresql:`  | PostgreSQL |
 
 Unsupported schemes should fail startup with a redacted connection string. The default development
 configuration should remain MongoDB for backward compatibility.
@@ -188,12 +188,12 @@ change.
 
 Other options considered:
 
-| Option | Reason not chosen |
-| --- | --- |
-| Prisma | Excellent generated client, but PostgreSQL-specific upsert details and array set-union updates are more awkward. Generated client lifecycle is also a larger shift for this service. |
-| TypeORM | Mature, but its entity/decorator lifecycle model is heavier than needed and less aligned with explicit backend actions. |
-| Sequelize | Runtime-model oriented and weaker TypeScript/schema ergonomics for a new TypeScript migration. |
-| Kysely or raw `pg` | Good SQL control, but not an ORM in the desired sense and would require more hand-rolled schema/migration conventions. |
+| Option             | Reason not chosen                                                                                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Prisma             | Excellent generated client, but PostgreSQL-specific upsert details and array set-union updates are more awkward. Generated client lifecycle is also a larger shift for this service. |
+| TypeORM            | Mature, but its entity/decorator lifecycle model is heavier than needed and less aligned with explicit backend actions.                                                              |
+| Sequelize          | Runtime-model oriented and weaker TypeScript/schema ergonomics for a new TypeScript migration.                                                                                       |
+| Kysely or raw `pg` | Good SQL control, but not an ORM in the desired sense and would require more hand-rolled schema/migration conventions.                                                               |
 
 Raw SQL fragments are acceptable inside Drizzle expressions for small PostgreSQL-specific pieces such
 as `least`, `greatest`, JSONB/array set-union updates, or generated export IDs when Drizzle cannot
@@ -376,37 +376,38 @@ Schema conventions:
 
 `data_dump_runs`:
 
-| Column | Type | Contract |
-| --- | --- | --- |
-| `id` | `bigint identity` | Primary key. |
-| `dump_month` | `date` | Not null; first JST calendar date of the Dump Month. |
-| `schema_version` | `integer` | Not null. |
-| `status` | `text` | Not null; one of `pending`, `exporting`, `uploaded`, `published`, `cleanup_eligible`, `cleaned`, `failed`. |
-| `manifest_object_key` | `text` | Nullable until upload. |
-| `manifest_bytes` | `bigint` | Nullable until publication; non-negative. |
-| `manifest_sha256` | `bytea` | Nullable until publication; exactly 32 bytes. |
-| `published_at` | `timestamptz` | Nullable. |
-| `cleanup_eligible_at` | `timestamptz` | Nullable; exactly seven days after publication. |
-| `cleaned_at` | `timestamptz` | Nullable. |
-| `error` | `text` | Nullable; last actionable failure. |
-| `created_at` | `timestamptz` | Not null, default `clock_timestamp()`. |
-| `updated_at` | `timestamptz` | Not null, default `clock_timestamp()` and updated on each state transition. |
+| Column                | Type              | Contract                                                                                                   |
+| --------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------- |
+| `id`                  | `bigint identity` | Primary key.                                                                                               |
+| `dump_month`          | `date`            | Not null; first JST calendar date of the Dump Month.                                                       |
+| `schema_version`      | `integer`         | Not null.                                                                                                  |
+| `status`              | `text`            | Not null; one of `pending`, `exporting`, `uploaded`, `published`, `cleanup_eligible`, `cleaned`, `failed`. |
+| `manifest_object_key` | `text`            | Nullable until upload.                                                                                     |
+| `manifest_bytes`      | `bigint`          | Nullable until publication; non-negative.                                                                  |
+| `manifest_sha256`     | `bytea`           | Nullable until publication; exactly 32 bytes.                                                              |
+| `published_at`        | `timestamptz`     | Nullable.                                                                                                  |
+| `cleanup_eligible_at` | `timestamptz`     | Nullable; exactly seven days after publication.                                                            |
+| `cleaned_at`          | `timestamptz`     | Nullable.                                                                                                  |
+| `error`               | `text`            | Nullable; last actionable failure.                                                                         |
+| `created_at`          | `timestamptz`     | Not null, default `clock_timestamp()`.                                                                     |
+| `updated_at`          | `timestamptz`     | Not null, default `clock_timestamp()` and updated on each state transition.                                |
 
-Add a unique constraint on `(dump_month, schema_version)`.
+Add a unique constraint on `dump_month`. Each Dump Month has one canonical immutable publication;
+`schema_version` records its manifest/data format rather than creating a second publication identity.
 
 `data_dump_files`:
 
-| Column | Type | Contract |
-| --- | --- | --- |
-| `id` | `bigint identity` | Primary key. |
-| `dump_run_id` | `bigint` | Not null; references `data_dump_runs(id)` with restricted delete. |
-| `dataset` | `text` | Not null; one of the nine Observation dataset names. |
-| `partition_name` | `text` | Not null. |
-| `object_key` | `text` | Not null. |
-| `row_count` | `bigint` | Not null and non-negative. |
-| `compressed_bytes` | `bigint` | Not null and non-negative. |
-| `sha256` | `bytea` | Not null; exactly 32 bytes. |
-| `verified_at` | `timestamptz` | Nullable until R2 verification. |
+| Column             | Type              | Contract                                                          |
+| ------------------ | ----------------- | ----------------------------------------------------------------- |
+| `id`               | `bigint identity` | Primary key.                                                      |
+| `dump_run_id`      | `bigint`          | Not null; references `data_dump_runs(id)` with restricted delete. |
+| `dataset`          | `text`            | Not null; one of the nine Observation dataset names.              |
+| `partition_name`   | `text`            | Not null.                                                         |
+| `object_key`       | `text`            | Not null.                                                         |
+| `row_count`        | `bigint`          | Not null and non-negative.                                        |
+| `compressed_bytes` | `bigint`          | Not null and non-negative.                                        |
+| `sha256`           | `bytea`           | Not null; exactly 32 bytes.                                       |
+| `verified_at`      | `timestamptz`     | Nullable until R2 verification.                                   |
 
 Add a unique constraint on `(dump_run_id, dataset)`.
 
@@ -414,26 +415,26 @@ Add a unique constraint on `(dump_run_id, dataset)`.
 
 Every Observation table is range-partitioned by `ingested_at` and starts with these columns:
 
-| Column | Type | Contract |
-| --- | --- | --- |
-| `id` | `bigint identity` | Not null. |
-| `ingested_at` | `timestamptz` | Not null, default `clock_timestamp()`. |
+| Column        | Type              | Contract                               |
+| ------------- | ----------------- | -------------------------------------- |
+| `id`          | `bigint identity` | Not null.                              |
+| `ingested_at` | `timestamptz`     | Not null, default `clock_timestamp()`. |
 
 The primary key is `(ingested_at, id)`. Scalar payload columns below are nullable to preserve legacy
 missing fields. Array payload columns are nullable with an empty-array default, preserving current
 Mongoose omitted-array behavior.
 
-| Table | Declared payload columns |
-| --- | --- |
-| `create_ship_records` | `items integer[]`, `kdock_id integer`, `secretary integer`, `ship_id integer`, `highspeed integer`, `teitoku_lv integer`, `large_flag boolean`, `origin text` |
-| `create_item_records` | `items integer[]`, `secretary integer`, `item_id integer`, `teitoku_lv integer`, `successful boolean`, `origin text` |
-| `remodel_item_records` | `successful boolean`, `item_id integer`, `item_level integer`, `flagship_id integer`, `flagship_level integer`, `flagship_cond integer`, `consort_id integer`, `consort_level integer`, `consort_cond integer`, `teitoku_lv integer`, `certain boolean` |
-| `drop_ship_records` | `ship_id integer`, `item_id integer`, `map_id integer`, `quest text`, `cell_id integer`, `enemy text`, `rank text`, `is_boss boolean`, `teitoku_lv integer`, `map_lv integer`, `enemy_ships1 integer[]`, `enemy_ships2 integer[]`, `enemy_formation integer`, `base_exp integer`, `teitoku_id text`, `owned_ship_snapshot jsonb`, `origin text` |
-| `pass_event_records` | `teitoku_id text`, `teitoku_lv integer`, `map_id integer`, `map_lv integer`, `rewards jsonb DEFAULT '[]'`, `origin text` |
-| `battle_apis` | `origin text`, `path text`, `data jsonb` |
-| `night_contacts` | `fleet_type integer`, `ship_id integer`, `ship_lv integer`, `item_id integer`, `item_lv integer`, `contact boolean` |
-| `aaci_records` | `poi_version text`, `available integer[]`, `triggered integer`, `items integer[]`, `improvement integer[]`, `raw_luck integer`, `raw_taiku integer`, `lv integer`, `hp_percent double precision`, `pos integer`, `origin text` |
-| `night_battle_cis` | `ship_id integer`, `ci text`, `type text`, `lv integer`, `raw_luck integer`, `pos integer`, `status text`, `items integer[]`, `improvement integer[]`, `search_light boolean`, `flare integer`, `defense_id integer`, `defense_type_id integer`, `ci_type integer`, `display integer[]`, `hit_type integer[]`, `damage double precision[]`, `damage_total double precision`, `time bigint`, `origin text` |
+| Table                  | Declared payload columns                                                                                                                                                                                                                                                                                                                                                                                  |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `create_ship_records`  | `items integer[]`, `kdock_id integer`, `secretary integer`, `ship_id integer`, `highspeed integer`, `teitoku_lv integer`, `large_flag boolean`, `origin text`                                                                                                                                                                                                                                             |
+| `create_item_records`  | `items integer[]`, `secretary integer`, `item_id integer`, `teitoku_lv integer`, `successful boolean`, `origin text`                                                                                                                                                                                                                                                                                      |
+| `remodel_item_records` | `successful boolean`, `item_id integer`, `item_level integer`, `flagship_id integer`, `flagship_level integer`, `flagship_cond integer`, `consort_id integer`, `consort_level integer`, `consort_cond integer`, `teitoku_lv integer`, `certain boolean`                                                                                                                                                   |
+| `drop_ship_records`    | `ship_id integer`, `item_id integer`, `map_id integer`, `quest text`, `cell_id integer`, `enemy text`, `rank text`, `is_boss boolean`, `teitoku_lv integer`, `map_lv integer`, `enemy_ships1 integer[]`, `enemy_ships2 integer[]`, `enemy_formation integer`, `base_exp integer`, `teitoku_id text`, `owned_ship_snapshot jsonb`, `origin text`                                                           |
+| `pass_event_records`   | `teitoku_id text`, `teitoku_lv integer`, `map_id integer`, `map_lv integer`, `rewards jsonb DEFAULT '[]'`, `origin text`                                                                                                                                                                                                                                                                                  |
+| `battle_apis`          | `origin text`, `path text`, `data jsonb`                                                                                                                                                                                                                                                                                                                                                                  |
+| `night_contacts`       | `fleet_type integer`, `ship_id integer`, `ship_lv integer`, `item_id integer`, `item_lv integer`, `contact boolean`                                                                                                                                                                                                                                                                                       |
+| `aaci_records`         | `poi_version text`, `available integer[]`, `triggered integer`, `items integer[]`, `improvement integer[]`, `raw_luck integer`, `raw_taiku integer`, `lv integer`, `hp_percent double precision`, `pos integer`, `origin text`                                                                                                                                                                            |
+| `night_battle_cis`     | `ship_id integer`, `ci text`, `type text`, `lv integer`, `raw_luck integer`, `pos integer`, `status text`, `items integer[]`, `improvement integer[]`, `search_light boolean`, `flare integer`, `defense_id integer`, `defense_type_id integer`, `ci_type integer`, `display integer[]`, `hit_type integer[]`, `damage double precision[]`, `damage_total double precision`, `time bigint`, `origin text` |
 
 Do not add `ship_counts` to `drop_ship_records`: it exists in a TypeScript interface but is absent
 from the Mongoose schema and is currently discarded. Likewise, do not add `origin` to
@@ -443,27 +444,27 @@ from the Mongoose schema and is currently discarded. Likewise, do not add `origi
 
 `select_rank_records`:
 
-| Column | Type | Contract |
-| --- | --- | --- |
-| `id` | `bigint identity` | Primary key. |
-| `teitoku_id` | `text` | Not null; Domain Identity. |
-| `maparea_id` | `integer` | Not null; Domain Identity. |
-| `teitoku_lv` | `integer` | Nullable. |
-| `rank` | `integer` | Nullable. |
-| `origin` | `text` | Nullable. |
+| Column       | Type              | Contract                   |
+| ------------ | ----------------- | -------------------------- |
+| `id`         | `bigint identity` | Primary key.               |
+| `teitoku_id` | `text`            | Not null; Domain Identity. |
+| `maparea_id` | `integer`         | Not null; Domain Identity. |
+| `teitoku_lv` | `integer`         | Nullable.                  |
+| `rank`       | `integer`         | Nullable.                  |
+| `origin`     | `text`            | Nullable.                  |
 
 Unique `(teitoku_id, maparea_id)`. On conflict, replace `teitoku_lv`, `rank`, and `origin` with the
 new Report values, preserving explicit nulls.
 
 `recipe_records`:
 
-| Column group | Type and nullability |
-| --- | --- |
-| Primary key | `id bigint identity` |
-| Domain Identity | `recipe_id integer NOT NULL`, `item_id integer NOT NULL`, `stage integer NOT NULL`, `day integer NOT NULL`, `secretary integer NOT NULL` |
+| Column group            | Type and nullability                                                                                                                                                                   |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Primary key             | `id bigint identity`                                                                                                                                                                   |
+| Domain Identity         | `recipe_id integer NOT NULL`, `item_id integer NOT NULL`, `stage integer NOT NULL`, `day integer NOT NULL`, `secretary integer NOT NULL`                                               |
 | Nullable integer values | `fuel`, `ammo`, `steel`, `bauxite`, `req_item_id`, `req_item_count`, `buildkit`, `remodelkit`, `certain_buildkit`, `certain_remodelkit`, `upgrade_to_item_id`, `upgrade_to_item_level` |
-| Other values | `key text NULL`, `origin text NULL` |
-| Accumulation | `last_reported bigint NOT NULL`, `count bigint NOT NULL DEFAULT 1` |
+| Other values            | `key text NULL`, `origin text NULL`                                                                                                                                                    |
+| Accumulation            | `last_reported bigint NOT NULL`, `count bigint NOT NULL DEFAULT 1`                                                                                                                     |
 
 Unique `(recipe_id, item_id, stage, day, secretary)`. `stage === -1` remains a successful no-op.
 Insert with `count = 1`; on conflict increment `count`, set `last_reported` from database time, and
@@ -472,25 +473,25 @@ stored value; an explicit null does.
 
 `ship_stats`:
 
-| Column group | Type and nullability |
-| --- | --- |
-| Primary key | `id bigint identity` |
+| Column group    | Type and nullability                                                                                                                                                                                                  |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Primary key     | `id bigint identity`                                                                                                                                                                                                  |
 | Domain Identity | `ship_id integer NOT NULL`, `lv integer NOT NULL`, `los integer NOT NULL`, `los_max integer NOT NULL`, `asw integer NOT NULL`, `asw_max integer NOT NULL`, `evasion integer NOT NULL`, `evasion_max integer NOT NULL` |
-| Accumulation | `last_timestamp bigint NOT NULL`, `count bigint NOT NULL DEFAULT 1` |
+| Accumulation    | `last_timestamp bigint NOT NULL`, `count bigint NOT NULL DEFAULT 1`                                                                                                                                                   |
 
 Unique across the eight Domain Identity columns. Insert with `count = 1`; on conflict increment
 `count` and replace `last_timestamp` with database time.
 
 `enemy_infos`:
 
-| Column group | Type and nullability |
-| --- | --- |
-| Primary key | `id bigint identity` |
-| Identity digest | `identity_hash bytea NOT NULL`, exactly 32 bytes and unique |
-| Required flat arrays | `ships1 integer[]`, `levels1 integer[]`, `hp1 integer[]`, `ships2 integer[]`, `levels2 integer[]`, `hp2 integer[]` |
-| Required nested arrays | `stats1 jsonb`, `equips1 jsonb`, `stats2 jsonb`, `equips2 jsonb` |
-| Required scalar identity | `planes integer` |
-| Accumulation | `bombers_min integer NULL`, `bombers_max integer NULL`, `count bigint NOT NULL DEFAULT 1` |
+| Column group             | Type and nullability                                                                                               |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| Primary key              | `id bigint identity`                                                                                               |
+| Identity digest          | `identity_hash bytea NOT NULL`, exactly 32 bytes and unique                                                        |
+| Required flat arrays     | `ships1 integer[]`, `levels1 integer[]`, `hp1 integer[]`, `ships2 integer[]`, `levels2 integer[]`, `hp2 integer[]` |
+| Required nested arrays   | `stats1 jsonb`, `equips1 jsonb`, `stats2 jsonb`, `equips2 jsonb`                                                   |
+| Required scalar identity | `planes integer`                                                                                                   |
+| Accumulation             | `bombers_min integer NULL`, `bombers_max integer NULL`, `count bigint NOT NULL DEFAULT 1`                          |
 
 All identity components are `NOT NULL`. Insert with `count = 1`. On conflict, verify component
 equality, increment `count`, update `bombers_min` to the greater non-null value, and update
@@ -506,36 +507,36 @@ encoding the equivalent PostgreSQL expressions.
 
 `quests`:
 
-| Column | Type | Contract |
-| --- | --- | --- |
-| `id` | `bigint identity` | Primary key. |
-| `key` | `text` | Not null; 32 lowercase hexadecimal MD5 characters. |
-| `quest_id` | `integer` | Not null. |
-| `title` | `text` | Not null. |
-| `detail` | `text` | Not null. |
-| `category` | `integer` | Not null. |
-| `type` | `integer` | Nullable. |
-| `origin` | `text` | Nullable. |
+| Column     | Type              | Contract                                           |
+| ---------- | ----------------- | -------------------------------------------------- |
+| `id`       | `bigint identity` | Primary key.                                       |
+| `key`      | `text`            | Not null; 32 lowercase hexadecimal MD5 characters. |
+| `quest_id` | `integer`         | Not null.                                          |
+| `title`    | `text`            | Not null.                                          |
+| `detail`   | `text`            | Not null.                                          |
+| `category` | `integer`         | Not null.                                          |
+| `type`     | `integer`         | Nullable.                                          |
+| `origin`   | `text`            | Nullable.                                          |
 
 Unique `(key, quest_id, category)`. On conflict, verify `title` and `detail` match and otherwise do
 nothing, preserving `$setOnInsert` behavior.
 
 `quest_rewards`:
 
-| Column | Type | Contract |
-| --- | --- | --- |
-| `id` | `bigint identity` | Primary key. |
-| `key` | `text` | Not null; 32 lowercase hexadecimal MD5 characters. |
-| `quest_id` | `integer` | Not null. |
-| `title` | `text` | Not null. |
-| `detail` | `text` | Not null. |
-| `category` | `integer` | Nullable. |
-| `type` | `integer` | Nullable. |
-| `origin` | `text` | Nullable. |
-| `selections` | `integer[]` | Not null. |
-| `material` | `integer[]` | Nullable, default empty array. |
-| `bonus` | `jsonb` | Nullable, default JSON array `[]`. |
-| `bonus_count` | `integer` | Not null; parsed from legacy HTTP field `bounsCount`. |
+| Column        | Type              | Contract                                              |
+| ------------- | ----------------- | ----------------------------------------------------- |
+| `id`          | `bigint identity` | Primary key.                                          |
+| `key`         | `text`            | Not null; 32 lowercase hexadecimal MD5 characters.    |
+| `quest_id`    | `integer`         | Not null.                                             |
+| `title`       | `text`            | Not null.                                             |
+| `detail`      | `text`            | Not null.                                             |
+| `category`    | `integer`         | Nullable.                                             |
+| `type`        | `integer`         | Nullable.                                             |
+| `origin`      | `text`            | Nullable.                                             |
+| `selections`  | `integer[]`       | Not null.                                             |
+| `material`    | `integer[]`       | Nullable, default empty array.                        |
+| `bonus`       | `jsonb`           | Nullable, default JSON array `[]`.                    |
+| `bonus_count` | `integer`         | Not null; parsed from legacy HTTP field `bounsCount`. |
 
 Unique `(key, quest_id, selections, bonus_count)`. On conflict, verify `title` and `detail` match and
 otherwise do nothing.
@@ -544,24 +545,24 @@ otherwise do nothing.
 
 Create one shared sequence, `item_improvement_fact_id_seq`. Every Fact table has:
 
-| Column | Type | Contract |
-| --- | --- | --- |
-| `id` | `bigint` | Primary key, default `nextval('item_improvement_fact_id_seq')`. |
-| `export_id` | `text` | Stored generated value `lpad(to_hex(id), 24, '0')`; unique and constrained to 24 lowercase hexadecimal characters. |
-| `key` | `text` | Not null and unique. |
-| `schema_version` | `integer` | Not null. |
-| `recipe_id` | `integer` | Not null. |
-| `item_id` | `integer` | Not null. |
-| `day` | `integer` | Not null. |
-| `first_client_observed_at` | `bigint` | Not null. |
-| `last_client_observed_at` | `bigint` | Not null. |
-| `observed_second_ship_id` | `integer` | Not null. |
-| `observed_flagship_ids` | `integer[]` | Not null, default empty array. |
-| `sources` | `text[]` | Not null, default empty array. |
-| `origins` | `text[]` | Not null, default empty array; private in exports. |
-| `first_reported` | `bigint` | Not null. |
-| `last_reported` | `bigint` | Not null. |
-| `count` | `bigint` | Not null, default `1`. |
+| Column                     | Type        | Contract                                                                                                           |
+| -------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------ |
+| `id`                       | `bigint`    | Primary key, default `nextval('item_improvement_fact_id_seq')`.                                                    |
+| `export_id`                | `text`      | Stored generated value `lpad(to_hex(id), 24, '0')`; unique and constrained to 24 lowercase hexadecimal characters. |
+| `key`                      | `text`      | Not null and unique.                                                                                               |
+| `schema_version`           | `integer`   | Not null.                                                                                                          |
+| `recipe_id`                | `integer`   | Not null.                                                                                                          |
+| `item_id`                  | `integer`   | Not null.                                                                                                          |
+| `day`                      | `integer`   | Not null.                                                                                                          |
+| `first_client_observed_at` | `bigint`    | Not null.                                                                                                          |
+| `last_client_observed_at`  | `bigint`    | Not null.                                                                                                          |
+| `observed_second_ship_id`  | `integer`   | Not null.                                                                                                          |
+| `observed_flagship_ids`    | `integer[]` | Not null, default empty array.                                                                                     |
+| `sources`                  | `text[]`    | Not null, default empty array.                                                                                     |
+| `origins`                  | `text[]`    | Not null, default empty array; private in exports.                                                                 |
+| `first_reported`           | `bigint`    | Not null.                                                                                                          |
+| `last_reported`            | `bigint`    | Not null.                                                                                                          |
+| `count`                    | `bigint`    | Not null, default `1`.                                                                                             |
 
 `item_improvement_availability_facts` adds no other columns.
 
@@ -621,8 +622,8 @@ Dump policy:
 Use object keys:
 
 ```text
-months/{YYYY-MM}/v{schemaVersion}/{dataset}.jsonl.zst
-months/{YYYY-MM}/v{schemaVersion}/manifest.json
+{YYYY-MM}/{dataset}.jsonl.zst
+{YYYY-MM}/manifest.json
 ```
 
 Manifest schema version 1:
@@ -657,16 +658,16 @@ interface CommunityDumpManifestV1 {
 
 Community Dump record schema version 1 uses these JSON keys in this exact order:
 
-| Dataset | Ordered keys after `observationId`, `ingestedAt` |
-| --- | --- |
-| `createShipObservations` | `items`, `kdockId`, `secretary`, `shipId`, `highspeed`, `teitokuLv`, `largeFlag`, `origin` |
-| `createItemObservations` | `items`, `secretary`, `itemId`, `teitokuLv`, `successful`, `origin` |
-| `remodelItemObservations` | `successful`, `itemId`, `itemLevel`, `flagshipId`, `flagshipLevel`, `flagshipCond`, `consortId`, `consortLevel`, `consortCond`, `teitokuLv`, `certain` |
-| `dropShipObservations` | `shipId`, `itemId`, `mapId`, `quest`, `cellId`, `enemy`, `rank`, `isBoss`, `teitokuLv`, `mapLv`, `enemyShips1`, `enemyShips2`, `enemyFormation`, `baseExp`, `teitokuId`, `ownedShipSnapshot`, `origin` |
-| `passEventObservations` | `teitokuId`, `teitokuLv`, `mapId`, `mapLv`, `rewards`, `origin` |
-| `battleApiObservations` | `origin`, `path`, `data` |
-| `nightContactObservations` | `fleetType`, `shipId`, `shipLv`, `itemId`, `itemLv`, `contact` |
-| `aaciObservations` | `poiVersion`, `available`, `triggered`, `items`, `improvement`, `rawLuck`, `rawTaiku`, `lv`, `hpPercent`, `pos`, `origin` |
+| Dataset                     | Ordered keys after `observationId`, `ingestedAt`                                                                                                                                                                  |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createShipObservations`    | `items`, `kdockId`, `secretary`, `shipId`, `highspeed`, `teitokuLv`, `largeFlag`, `origin`                                                                                                                        |
+| `createItemObservations`    | `items`, `secretary`, `itemId`, `teitokuLv`, `successful`, `origin`                                                                                                                                               |
+| `remodelItemObservations`   | `successful`, `itemId`, `itemLevel`, `flagshipId`, `flagshipLevel`, `flagshipCond`, `consortId`, `consortLevel`, `consortCond`, `teitokuLv`, `certain`                                                            |
+| `dropShipObservations`      | `shipId`, `itemId`, `mapId`, `quest`, `cellId`, `enemy`, `rank`, `isBoss`, `teitokuLv`, `mapLv`, `enemyShips1`, `enemyShips2`, `enemyFormation`, `baseExp`, `teitokuId`, `ownedShipSnapshot`, `origin`            |
+| `passEventObservations`     | `teitokuId`, `teitokuLv`, `mapId`, `mapLv`, `rewards`, `origin`                                                                                                                                                   |
+| `battleApiObservations`     | `origin`, `path`, `data`                                                                                                                                                                                          |
+| `nightContactObservations`  | `fleetType`, `shipId`, `shipLv`, `itemId`, `itemLv`, `contact`                                                                                                                                                    |
+| `aaciObservations`          | `poiVersion`, `available`, `triggered`, `items`, `improvement`, `rawLuck`, `rawTaiku`, `lv`, `hpPercent`, `pos`, `origin`                                                                                         |
 | `nightBattleCiObservations` | `shipId`, `CI`, `type`, `lv`, `rawLuck`, `pos`, `status`, `items`, `improvement`, `searchLight`, `flare`, `defenseId`, `defenseTypeId`, `ciType`, `display`, `hitType`, `damage`, `damageTotal`, `time`, `origin` |
 
 Serialization rules:
@@ -747,15 +748,15 @@ Important indexes and constraints:
 
 Concrete PostgreSQL upsert keys:
 
-| Table | Upsert/uniqueness key |
-| --- | --- |
-| `select_rank_records` | `(teitoku_id, maparea_id)` |
-| `recipe_records` | `(recipe_id, item_id, stage, day, secretary)` |
-| `ship_stats` | `(ship_id, lv, los, los_max, asw, asw_max, evasion, evasion_max)` |
-| `enemy_infos` | SHA-256 of an ordered JSON tuple containing `ships1`, `levels1`, `hp1`, `stats1`, `equips1`, `ships2`, `levels2`, `hp2`, `stats2`, `equips2`, and `planes`. |
-| `quests` | `(key, quest_id, category)` |
-| `quest_rewards` | `(key, quest_id, selections, bonus_count)` using PostgreSQL's native equality support for primitive array columns. The PostgreSQL column should use the corrected `bonus_count` name while the HTTP payload parser continues accepting the legacy `bounsCount` field. |
-| item-improvement facts | `key` |
+| Table                  | Upsert/uniqueness key                                                                                                                                                                                                                                                 |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `select_rank_records`  | `(teitoku_id, maparea_id)`                                                                                                                                                                                                                                            |
+| `recipe_records`       | `(recipe_id, item_id, stage, day, secretary)`                                                                                                                                                                                                                         |
+| `ship_stats`           | `(ship_id, lv, los, los_max, asw, asw_max, evasion, evasion_max)`                                                                                                                                                                                                     |
+| `enemy_infos`          | SHA-256 of an ordered JSON tuple containing `ships1`, `levels1`, `hp1`, `stats1`, `equips1`, `ships2`, `levels2`, `hp2`, `stats2`, `equips2`, and `planes`.                                                                                                           |
+| `quests`               | `(key, quest_id, category)`                                                                                                                                                                                                                                           |
+| `quest_rewards`        | `(key, quest_id, selections, bonus_count)` using PostgreSQL's native equality support for primitive array columns. The PostgreSQL column should use the corrected `bonus_count` name while the HTTP payload parser continues accepting the legacy `bounsCount` field. |
+| item-improvement facts | `key`                                                                                                                                                                                                                                                                 |
 
 These tuples are Domain Identities, not migration identifiers. Enforce each Domain Identity with a
 unique constraint so concurrent writes use one atomic `INSERT ... ON CONFLICT ... DO UPDATE` path
@@ -782,22 +783,22 @@ Enemy Info identity hashing must exactly preserve MongoDB's current equality sem
 
 ## Semantic mapping
 
-| Current MongoDB semantic | PostgreSQL/Drizzle design |
-| --- | --- |
-| `new Model(info).save()` | Validate and map declared fields explicitly, discard undeclared fields, and insert typed/declared JSONB columns |
-| status `count()` | MongoDB metadata estimate or PostgreSQL catalog estimate; exact counts are reserved for offline dump verification |
-| `distinct('questId')` | A Drizzle distinct projection such as `selectDistinct({ questId: table.questId }).from(table)`; preserve current endpoint sort behavior |
-| `findOne` then mutate/save for select rank | Unique key on `(teitoku_id, maparea_id)` with conflict update |
-| `$setOnInsert` | Conflict update with immutable insert-only fields omitted from the update set |
-| `$inc` | `count = table.count + 1` |
-| `$min` | `first_client_observed_at = least(existing, excluded)` |
-| `$max` | `last_reported = greatest(existing, excluded)` and same for client observed timestamp |
-| `$addToSet` scalar or `$each` arrays | PostgreSQL stable append-if-absent union that preserves existing order |
-| Mongoose ObjectId export cursor | Shared-sequence bigint encoded as a stored 24-character lowercase hexadecimal `export_id` |
-| `.select('-__v -origins')` | Explicit selected column list that excludes `origins` and maps internal `export_id` to public `_id` |
-| `.sort({ lastReported: 1, _id: 1 })` | `orderBy(last_reported asc, export_id asc)` |
-| Flexible nested Mongo fields | JSONB fields for payloads or snapshots that are not queried structurally |
-| `EnemyInfo` `$max: { bombersMin }`, `$min: { bombersMax }` | Presence-aware PostgreSQL expressions that reproduce the tested MongoDB numeric/null transitions |
+| Current MongoDB semantic                                   | PostgreSQL/Drizzle design                                                                                                               |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `new Model(info).save()`                                   | Validate and map declared fields explicitly, discard undeclared fields, and insert typed/declared JSONB columns                         |
+| status `count()`                                           | MongoDB metadata estimate or PostgreSQL catalog estimate; exact counts are reserved for offline dump verification                       |
+| `distinct('questId')`                                      | A Drizzle distinct projection such as `selectDistinct({ questId: table.questId }).from(table)`; preserve current endpoint sort behavior |
+| `findOne` then mutate/save for select rank                 | Unique key on `(teitoku_id, maparea_id)` with conflict update                                                                           |
+| `$setOnInsert`                                             | Conflict update with immutable insert-only fields omitted from the update set                                                           |
+| `$inc`                                                     | `count = table.count + 1`                                                                                                               |
+| `$min`                                                     | `first_client_observed_at = least(existing, excluded)`                                                                                  |
+| `$max`                                                     | `last_reported = greatest(existing, excluded)` and same for client observed timestamp                                                   |
+| `$addToSet` scalar or `$each` arrays                       | PostgreSQL stable append-if-absent union that preserves existing order                                                                  |
+| Mongoose ObjectId export cursor                            | Shared-sequence bigint encoded as a stored 24-character lowercase hexadecimal `export_id`                                               |
+| `.select('-__v -origins')`                                 | Explicit selected column list that excludes `origins` and maps internal `export_id` to public `_id`                                     |
+| `.sort({ lastReported: 1, _id: 1 })`                       | `orderBy(last_reported asc, export_id asc)`                                                                                             |
+| Flexible nested Mongo fields                               | JSONB fields for payloads or snapshots that are not queried structurally                                                                |
+| `EnemyInfo` `$max: { bombersMin }`, `$min: { bombersMax }` | Presence-aware PostgreSQL expressions that reproduce the tested MongoDB numeric/null transitions                                        |
 
 ## v3 item-improvement compatibility
 
@@ -912,50 +913,50 @@ The same HTTP behavior suite should run against both backends where possible.
 
 The test contract matrix maps behavior to required MongoDB and PostgreSQL assertions:
 
-| Area | Required parity coverage |
-| --- | --- |
-| Backend config | URI scheme selects MongoDB or PostgreSQL; unsupported schemes fail with redacted errors. |
-| `/api/status` | Both backends return the same backend-neutral `database` shape; the legacy `mongo` field is absent. |
-| v2 observations | Each report endpoint persists the declared fields and discards undeclared fields consistently on both backends. |
-| v2 upserts | `select_rank`, `remodel_recipe`, `ship_stat`, and `enemy_info` match current update behavior, including Enemy Info absent/null/numeric bomber transitions. |
-| v2 compatibility routes | `known_quests`, `known_recipes`, `quest/:id`, `remodel_recipe_deduplicate`, and `night_battle_ss_ci` keep current response behavior. |
-| v3 quests | Quest and reward keys, uniqueness, known quest prefixes, and legacy `bounsCount` payload handling match MongoDB behavior. |
-| v3 item-improvement ingest | Keys, normalization, `$setOnInsert` equivalents, min/max timestamps, stable append-if-absent arrays, origins, and counts match MongoDB behavior. |
-| v3 item-improvement export | Both backends cover limit clamping, origin omission, numeric timestamps, public `_id`, cursor canonicalization, ordering, and empty pages; PostgreSQL additionally covers database-time settled pagination. |
-| Monthly dumps and retention | All nine versioned JSONL serializers, manifest/object read-back verification, default-partition repair, grace period, catalog-bound partition verification, and cleanup classifications pass. |
-| Error handling | Malformed JSON, invalid payloads, invalid cursors, and database errors preserve current status/body behavior. |
-| Shared validation | Both backends preserve documented Mongoose casting/defaults, enforce int32/safe-bigint ranges, reject cast failures, missing Domain Identity, invalid AACI semver, or fractional integral fields with the same 400 body, and emit bounded structured validation logs. |
+| Area                        | Required parity coverage                                                                                                                                                                                                                                              |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Backend config              | URI scheme selects MongoDB or PostgreSQL; unsupported schemes fail with redacted errors.                                                                                                                                                                              |
+| `/api/status`               | Both backends return the same backend-neutral `database` shape; the legacy `mongo` field is absent.                                                                                                                                                                   |
+| v2 observations             | Each report endpoint persists the declared fields and discards undeclared fields consistently on both backends.                                                                                                                                                       |
+| v2 upserts                  | `select_rank`, `remodel_recipe`, `ship_stat`, and `enemy_info` match current update behavior, including Enemy Info absent/null/numeric bomber transitions.                                                                                                            |
+| v2 compatibility routes     | `known_quests`, `known_recipes`, `quest/:id`, `remodel_recipe_deduplicate`, and `night_battle_ss_ci` keep current response behavior.                                                                                                                                  |
+| v3 quests                   | Quest and reward keys, uniqueness, known quest prefixes, and legacy `bounsCount` payload handling match MongoDB behavior.                                                                                                                                             |
+| v3 item-improvement ingest  | Keys, normalization, `$setOnInsert` equivalents, min/max timestamps, stable append-if-absent arrays, origins, and counts match MongoDB behavior.                                                                                                                      |
+| v3 item-improvement export  | Both backends cover limit clamping, origin omission, numeric timestamps, public `_id`, cursor canonicalization, ordering, and empty pages; PostgreSQL additionally covers database-time settled pagination.                                                           |
+| Monthly dumps and retention | All nine versioned JSONL serializers, manifest/object read-back verification, default-partition repair, grace period, catalog-bound partition verification, and cleanup classifications pass.                                                                         |
+| Error handling              | Malformed JSON, invalid payloads, invalid cursors, and database errors preserve current status/body behavior.                                                                                                                                                         |
+| Shared validation           | Both backends preserve documented Mongoose casting/defaults, enforce int32/safe-bigint ranges, reject cast failures, missing Domain Identity, invalid AACI semver, or fractional integral fields with the same 400 body, and emit bounded structured validation logs. |
 
 Endpoint-level required cases:
 
-| Endpoint | Required behavior assertions on both backends |
-| --- | --- |
-| `POST /api/report/v2/create_ship` | Declared fields persist once; omitted arrays become empty; unknown fields are discarded. |
-| `POST /api/report/v2/create_item` | Declared fields persist once with shared casting and integer validation. |
-| `POST /api/report/v2/remodel_item` | Declared fields persist once; injected `origin` is discarded because it is not in the legacy schema. |
-| `POST /api/report/v2/drop_ship` | `ownedShipSnapshot` becomes `{}` for `mapId < 73`; otherwise declared JSON is retained. |
-| `POST /api/report/v2/select_rank` | Repeated Domain Identity replaces current level/rank/origin and does not add a second row. |
-| `POST /api/report/v2/pass_event` | Declared reward objects persist in order; omitted rewards normalize to an empty array. |
-| `GET /api/report/v2/known_quests` | Returns distinct quest IDs with the current JavaScript default sort behavior and Cloudflare cache headers. |
-| `POST /api/report/v2/quest/:id` | Returns 200 and performs no write. |
-| `POST /api/report/v2/battle_api` | Declared `path`, `origin`, and arbitrary JSON `data` persist; unknown top-level fields are discarded. |
-| `POST /api/report/v2/night_contcat` | Misspelled route remains registered; declared fields persist; injected `origin` is discarded. |
-| `POST /api/report/v2/aaci` | Invalid/missing semantic versions return logged 400; writes only when all current POI/reporter version gates pass; all other valid reports return 200 without a write. |
-| `GET /api/report/v2/known_recipes` | Returns `{ recipes: [] }`. |
-| `POST /api/report/v2/remodel_recipe` | `stage === -1` is a no-op; otherwise insert/count/update semantics follow the exact Aggregate contract. |
-| `POST /api/report/v2/remodel_recipe_deduplicate` | MongoDB removes legacy duplicates; PostgreSQL normally returns an empty deletion list because Domain Identity is unique. |
-| `POST /api/report/v2/night_battle_ci` | Fractional `damage` and `damageTotal` round-trip; millisecond `time` remains a JSON number. |
-| `POST /api/report/v2/night_battle_ss_ci` | Returns 200 and performs no write. |
-| `POST /api/report/v2/ship_stat` | Domain Identity inserts once, then atomically increments count and advances `last_timestamp`. |
-| `POST /api/report/v2/enemy_info` | Ordered identity hashing matches Mongo tuple equality; count increments; min/max null and intersection rules match. |
-| `POST /api/report/v3/item_improvement_recipe` | Single and batch forms normalize identically; maximum batch 100; partial-write behavior on database failure matches the current per-record writes; response count is correct. |
-| `GET /api/report/v3/item_improvement_recipes/availability` | Filters, clamp, public `_id`, cursor, omission of origins, and cache headers match; PostgreSQL alone applies the settled window. |
-| `GET /api/report/v3/item_improvement_recipes/costs` | Same backend-aware export contract plus required-item JSON round-trip and stable arrays. |
-| `GET /api/report/v3/item_improvement_recipes/updates` | Same backend-aware export contract plus upgrade fields. |
-| `GET /api/report/v3/known_quests` | Returns distinct eight-character quest-key prefixes with Cloudflare cache headers. |
-| `POST /api/report/v3/quest` | Every quest in the Report uses MD5 title/detail keying and insert-only Definition semantics. |
-| `POST /api/report/v3/quest_reward` | Accepts legacy `bounsCount`, stores `bonus_count`, preserves material/bonus structures, and inserts only once per Domain Identity. |
-| `GET /api/status` | Returns `env`, `disk`, and the exact backend-neutral `database` shape with all 18 estimated counts. |
+| Endpoint                                                   | Required behavior assertions on both backends                                                                                                                                 |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /api/report/v2/create_ship`                          | Declared fields persist once; omitted arrays become empty; unknown fields are discarded.                                                                                      |
+| `POST /api/report/v2/create_item`                          | Declared fields persist once with shared casting and integer validation.                                                                                                      |
+| `POST /api/report/v2/remodel_item`                         | Declared fields persist once; injected `origin` is discarded because it is not in the legacy schema.                                                                          |
+| `POST /api/report/v2/drop_ship`                            | `ownedShipSnapshot` becomes `{}` for `mapId < 73`; otherwise declared JSON is retained.                                                                                       |
+| `POST /api/report/v2/select_rank`                          | Repeated Domain Identity replaces current level/rank/origin and does not add a second row.                                                                                    |
+| `POST /api/report/v2/pass_event`                           | Declared reward objects persist in order; omitted rewards normalize to an empty array.                                                                                        |
+| `GET /api/report/v2/known_quests`                          | Returns distinct quest IDs with the current JavaScript default sort behavior and Cloudflare cache headers.                                                                    |
+| `POST /api/report/v2/quest/:id`                            | Returns 200 and performs no write.                                                                                                                                            |
+| `POST /api/report/v2/battle_api`                           | Declared `path`, `origin`, and arbitrary JSON `data` persist; unknown top-level fields are discarded.                                                                         |
+| `POST /api/report/v2/night_contcat`                        | Misspelled route remains registered; declared fields persist; injected `origin` is discarded.                                                                                 |
+| `POST /api/report/v2/aaci`                                 | Invalid/missing semantic versions return logged 400; writes only when all current POI/reporter version gates pass; all other valid reports return 200 without a write.        |
+| `GET /api/report/v2/known_recipes`                         | Returns `{ recipes: [] }`.                                                                                                                                                    |
+| `POST /api/report/v2/remodel_recipe`                       | `stage === -1` is a no-op; otherwise insert/count/update semantics follow the exact Aggregate contract.                                                                       |
+| `POST /api/report/v2/remodel_recipe_deduplicate`           | MongoDB removes legacy duplicates; PostgreSQL normally returns an empty deletion list because Domain Identity is unique.                                                      |
+| `POST /api/report/v2/night_battle_ci`                      | Fractional `damage` and `damageTotal` round-trip; millisecond `time` remains a JSON number.                                                                                   |
+| `POST /api/report/v2/night_battle_ss_ci`                   | Returns 200 and performs no write.                                                                                                                                            |
+| `POST /api/report/v2/ship_stat`                            | Domain Identity inserts once, then atomically increments count and advances `last_timestamp`.                                                                                 |
+| `POST /api/report/v2/enemy_info`                           | Ordered identity hashing matches Mongo tuple equality; count increments; min/max null and intersection rules match.                                                           |
+| `POST /api/report/v3/item_improvement_recipe`              | Single and batch forms normalize identically; maximum batch 100; partial-write behavior on database failure matches the current per-record writes; response count is correct. |
+| `GET /api/report/v3/item_improvement_recipes/availability` | Filters, clamp, public `_id`, cursor, omission of origins, and cache headers match; PostgreSQL alone applies the settled window.                                              |
+| `GET /api/report/v3/item_improvement_recipes/costs`        | Same backend-aware export contract plus required-item JSON round-trip and stable arrays.                                                                                      |
+| `GET /api/report/v3/item_improvement_recipes/updates`      | Same backend-aware export contract plus upgrade fields.                                                                                                                       |
+| `GET /api/report/v3/known_quests`                          | Returns distinct eight-character quest-key prefixes with Cloudflare cache headers.                                                                                            |
+| `POST /api/report/v3/quest`                                | Every quest in the Report uses MD5 title/detail keying and insert-only Definition semantics.                                                                                  |
+| `POST /api/report/v3/quest_reward`                         | Accepts legacy `bounsCount`, stores `bonus_count`, preserves material/bonus structures, and inserts only once per Domain Identity.                                            |
+| `GET /api/status`                                          | Returns `env`, `disk`, and the exact backend-neutral `database` shape with all 18 estimated counts.                                                                           |
 
 Implementation is not complete until the parity matrix passes against MongoDB and a real PostgreSQL
 service in CI. PGlite-only coverage is insufficient for accepting the PostgreSQL backend.

--- a/docs/postgresql-migration-plan.md
+++ b/docs/postgresql-migration-plan.md
@@ -41,12 +41,12 @@ const databaseUrl = process.env.POI_SERVER_DATABASE_URL ?? process.env.POI_SERVE
 
 Backend selection maps URI schemes as follows:
 
-| URI scheme     | Backend    |
-| -------------- | ---------- |
-| `mongodb:`     | MongoDB    |
-| `mongodb+srv:` | MongoDB    |
-| `postgres:`    | PostgreSQL |
-| `postgresql:`  | PostgreSQL |
+| URI scheme | Backend |
+| --- | --- |
+| `mongodb:` | MongoDB |
+| `mongodb+srv:` | MongoDB |
+| `postgres:` | PostgreSQL |
+| `postgresql:` | PostgreSQL |
 
 Unsupported schemes should fail startup with a redacted connection string. The default development
 configuration should remain MongoDB for backward compatibility.
@@ -188,12 +188,12 @@ change.
 
 Other options considered:
 
-| Option             | Reason not chosen                                                                                                                                                                    |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Prisma             | Excellent generated client, but PostgreSQL-specific upsert details and array set-union updates are more awkward. Generated client lifecycle is also a larger shift for this service. |
-| TypeORM            | Mature, but its entity/decorator lifecycle model is heavier than needed and less aligned with explicit backend actions.                                                              |
-| Sequelize          | Runtime-model oriented and weaker TypeScript/schema ergonomics for a new TypeScript migration.                                                                                       |
-| Kysely or raw `pg` | Good SQL control, but not an ORM in the desired sense and would require more hand-rolled schema/migration conventions.                                                               |
+| Option | Reason not chosen |
+| --- | --- |
+| Prisma | Excellent generated client, but PostgreSQL-specific upsert details and array set-union updates are more awkward. Generated client lifecycle is also a larger shift for this service. |
+| TypeORM | Mature, but its entity/decorator lifecycle model is heavier than needed and less aligned with explicit backend actions. |
+| Sequelize | Runtime-model oriented and weaker TypeScript/schema ergonomics for a new TypeScript migration. |
+| Kysely or raw `pg` | Good SQL control, but not an ORM in the desired sense and would require more hand-rolled schema/migration conventions. |
 
 Raw SQL fragments are acceptable inside Drizzle expressions for small PostgreSQL-specific pieces such
 as `least`, `greatest`, JSONB/array set-union updates, or generated export IDs when Drizzle cannot
@@ -376,38 +376,38 @@ Schema conventions:
 
 `data_dump_runs`:
 
-| Column                | Type              | Contract                                                                                                   |
-| --------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------- |
-| `id`                  | `bigint identity` | Primary key.                                                                                               |
-| `dump_month`          | `date`            | Not null; first JST calendar date of the Dump Month.                                                       |
-| `schema_version`      | `integer`         | Not null.                                                                                                  |
-| `status`              | `text`            | Not null; one of `pending`, `exporting`, `uploaded`, `published`, `cleanup_eligible`, `cleaned`, `failed`. |
-| `manifest_object_key` | `text`            | Nullable until upload.                                                                                     |
-| `manifest_bytes`      | `bigint`          | Nullable until publication; non-negative.                                                                  |
-| `manifest_sha256`     | `bytea`           | Nullable until publication; exactly 32 bytes.                                                              |
-| `published_at`        | `timestamptz`     | Nullable.                                                                                                  |
-| `cleanup_eligible_at` | `timestamptz`     | Nullable; exactly seven days after publication.                                                            |
-| `cleaned_at`          | `timestamptz`     | Nullable.                                                                                                  |
-| `error`               | `text`            | Nullable; last actionable failure.                                                                         |
-| `created_at`          | `timestamptz`     | Not null, default `clock_timestamp()`.                                                                     |
-| `updated_at`          | `timestamptz`     | Not null, default `clock_timestamp()` and updated on each state transition.                                |
+| Column | Type | Contract |
+| --- | --- | --- |
+| `id` | `bigint identity` | Primary key. |
+| `dump_month` | `date` | Not null; first JST calendar date of the Dump Month. |
+| `schema_version` | `integer` | Not null. |
+| `status` | `text` | Not null; one of `pending`, `exporting`, `uploaded`, `published`, `cleanup_eligible`, `cleaned`, `failed`. |
+| `manifest_object_key` | `text` | Nullable until upload. |
+| `manifest_bytes` | `bigint` | Nullable until publication; non-negative. |
+| `manifest_sha256` | `bytea` | Nullable until publication; exactly 32 bytes. |
+| `published_at` | `timestamptz` | Nullable. |
+| `cleanup_eligible_at` | `timestamptz` | Nullable; exactly seven days after publication. |
+| `cleaned_at` | `timestamptz` | Nullable. |
+| `error` | `text` | Nullable; last actionable failure. |
+| `created_at` | `timestamptz` | Not null, default `clock_timestamp()`. |
+| `updated_at` | `timestamptz` | Not null, default `clock_timestamp()` and updated on each state transition. |
 
 Add a unique constraint on `dump_month`. Each Dump Month has one canonical immutable publication;
 `schema_version` records its manifest/data format rather than creating a second publication identity.
 
 `data_dump_files`:
 
-| Column             | Type              | Contract                                                          |
-| ------------------ | ----------------- | ----------------------------------------------------------------- |
-| `id`               | `bigint identity` | Primary key.                                                      |
-| `dump_run_id`      | `bigint`          | Not null; references `data_dump_runs(id)` with restricted delete. |
-| `dataset`          | `text`            | Not null; one of the nine Observation dataset names.              |
-| `partition_name`   | `text`            | Not null.                                                         |
-| `object_key`       | `text`            | Not null.                                                         |
-| `row_count`        | `bigint`          | Not null and non-negative.                                        |
-| `compressed_bytes` | `bigint`          | Not null and non-negative.                                        |
-| `sha256`           | `bytea`           | Not null; exactly 32 bytes.                                       |
-| `verified_at`      | `timestamptz`     | Nullable until R2 verification.                                   |
+| Column | Type | Contract |
+| --- | --- | --- |
+| `id` | `bigint identity` | Primary key. |
+| `dump_run_id` | `bigint` | Not null; references `data_dump_runs(id)` with restricted delete. |
+| `dataset` | `text` | Not null; one of the nine Observation dataset names. |
+| `partition_name` | `text` | Not null. |
+| `object_key` | `text` | Not null. |
+| `row_count` | `bigint` | Not null and non-negative. |
+| `compressed_bytes` | `bigint` | Not null and non-negative. |
+| `sha256` | `bytea` | Not null; exactly 32 bytes. |
+| `verified_at` | `timestamptz` | Nullable until R2 verification. |
 
 Add a unique constraint on `(dump_run_id, dataset)`.
 
@@ -415,26 +415,26 @@ Add a unique constraint on `(dump_run_id, dataset)`.
 
 Every Observation table is range-partitioned by `ingested_at` and starts with these columns:
 
-| Column        | Type              | Contract                               |
-| ------------- | ----------------- | -------------------------------------- |
-| `id`          | `bigint identity` | Not null.                              |
-| `ingested_at` | `timestamptz`     | Not null, default `clock_timestamp()`. |
+| Column | Type | Contract |
+| --- | --- | --- |
+| `id` | `bigint identity` | Not null. |
+| `ingested_at` | `timestamptz` | Not null, default `clock_timestamp()`. |
 
 The primary key is `(ingested_at, id)`. Scalar payload columns below are nullable to preserve legacy
 missing fields. Array payload columns are nullable with an empty-array default, preserving current
 Mongoose omitted-array behavior.
 
-| Table                  | Declared payload columns                                                                                                                                                                                                                                                                                                                                                                                  |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `create_ship_records`  | `items integer[]`, `kdock_id integer`, `secretary integer`, `ship_id integer`, `highspeed integer`, `teitoku_lv integer`, `large_flag boolean`, `origin text`                                                                                                                                                                                                                                             |
-| `create_item_records`  | `items integer[]`, `secretary integer`, `item_id integer`, `teitoku_lv integer`, `successful boolean`, `origin text`                                                                                                                                                                                                                                                                                      |
-| `remodel_item_records` | `successful boolean`, `item_id integer`, `item_level integer`, `flagship_id integer`, `flagship_level integer`, `flagship_cond integer`, `consort_id integer`, `consort_level integer`, `consort_cond integer`, `teitoku_lv integer`, `certain boolean`                                                                                                                                                   |
-| `drop_ship_records`    | `ship_id integer`, `item_id integer`, `map_id integer`, `quest text`, `cell_id integer`, `enemy text`, `rank text`, `is_boss boolean`, `teitoku_lv integer`, `map_lv integer`, `enemy_ships1 integer[]`, `enemy_ships2 integer[]`, `enemy_formation integer`, `base_exp integer`, `teitoku_id text`, `owned_ship_snapshot jsonb`, `origin text`                                                           |
-| `pass_event_records`   | `teitoku_id text`, `teitoku_lv integer`, `map_id integer`, `map_lv integer`, `rewards jsonb DEFAULT '[]'`, `origin text`                                                                                                                                                                                                                                                                                  |
-| `battle_apis`          | `origin text`, `path text`, `data jsonb`                                                                                                                                                                                                                                                                                                                                                                  |
-| `night_contacts`       | `fleet_type integer`, `ship_id integer`, `ship_lv integer`, `item_id integer`, `item_lv integer`, `contact boolean`                                                                                                                                                                                                                                                                                       |
-| `aaci_records`         | `poi_version text`, `available integer[]`, `triggered integer`, `items integer[]`, `improvement integer[]`, `raw_luck integer`, `raw_taiku integer`, `lv integer`, `hp_percent double precision`, `pos integer`, `origin text`                                                                                                                                                                            |
-| `night_battle_cis`     | `ship_id integer`, `ci text`, `type text`, `lv integer`, `raw_luck integer`, `pos integer`, `status text`, `items integer[]`, `improvement integer[]`, `search_light boolean`, `flare integer`, `defense_id integer`, `defense_type_id integer`, `ci_type integer`, `display integer[]`, `hit_type integer[]`, `damage double precision[]`, `damage_total double precision`, `time bigint`, `origin text` |
+| Table | Declared payload columns |
+| --- | --- |
+| `create_ship_records` | `items integer[]`, `kdock_id integer`, `secretary integer`, `ship_id integer`, `highspeed integer`, `teitoku_lv integer`, `large_flag boolean`, `origin text` |
+| `create_item_records` | `items integer[]`, `secretary integer`, `item_id integer`, `teitoku_lv integer`, `successful boolean`, `origin text` |
+| `remodel_item_records` | `successful boolean`, `item_id integer`, `item_level integer`, `flagship_id integer`, `flagship_level integer`, `flagship_cond integer`, `consort_id integer`, `consort_level integer`, `consort_cond integer`, `teitoku_lv integer`, `certain boolean` |
+| `drop_ship_records` | `ship_id integer`, `item_id integer`, `map_id integer`, `quest text`, `cell_id integer`, `enemy text`, `rank text`, `is_boss boolean`, `teitoku_lv integer`, `map_lv integer`, `enemy_ships1 integer[]`, `enemy_ships2 integer[]`, `enemy_formation integer`, `base_exp integer`, `teitoku_id text`, `owned_ship_snapshot jsonb`, `origin text` |
+| `pass_event_records` | `teitoku_id text`, `teitoku_lv integer`, `map_id integer`, `map_lv integer`, `rewards jsonb DEFAULT '[]'`, `origin text` |
+| `battle_apis` | `origin text`, `path text`, `data jsonb` |
+| `night_contacts` | `fleet_type integer`, `ship_id integer`, `ship_lv integer`, `item_id integer`, `item_lv integer`, `contact boolean` |
+| `aaci_records` | `poi_version text`, `available integer[]`, `triggered integer`, `items integer[]`, `improvement integer[]`, `raw_luck integer`, `raw_taiku integer`, `lv integer`, `hp_percent double precision`, `pos integer`, `origin text` |
+| `night_battle_cis` | `ship_id integer`, `ci text`, `type text`, `lv integer`, `raw_luck integer`, `pos integer`, `status text`, `items integer[]`, `improvement integer[]`, `search_light boolean`, `flare integer`, `defense_id integer`, `defense_type_id integer`, `ci_type integer`, `display integer[]`, `hit_type integer[]`, `damage double precision[]`, `damage_total double precision`, `time bigint`, `origin text` |
 
 Do not add `ship_counts` to `drop_ship_records`: it exists in a TypeScript interface but is absent
 from the Mongoose schema and is currently discarded. Likewise, do not add `origin` to
@@ -444,27 +444,27 @@ from the Mongoose schema and is currently discarded. Likewise, do not add `origi
 
 `select_rank_records`:
 
-| Column       | Type              | Contract                   |
-| ------------ | ----------------- | -------------------------- |
-| `id`         | `bigint identity` | Primary key.               |
-| `teitoku_id` | `text`            | Not null; Domain Identity. |
-| `maparea_id` | `integer`         | Not null; Domain Identity. |
-| `teitoku_lv` | `integer`         | Nullable.                  |
-| `rank`       | `integer`         | Nullable.                  |
-| `origin`     | `text`            | Nullable.                  |
+| Column | Type | Contract |
+| --- | --- | --- |
+| `id` | `bigint identity` | Primary key. |
+| `teitoku_id` | `text` | Not null; Domain Identity. |
+| `maparea_id` | `integer` | Not null; Domain Identity. |
+| `teitoku_lv` | `integer` | Nullable. |
+| `rank` | `integer` | Nullable. |
+| `origin` | `text` | Nullable. |
 
 Unique `(teitoku_id, maparea_id)`. On conflict, replace `teitoku_lv`, `rank`, and `origin` with the
 new Report values, preserving explicit nulls.
 
 `recipe_records`:
 
-| Column group            | Type and nullability                                                                                                                                                                   |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Primary key             | `id bigint identity`                                                                                                                                                                   |
-| Domain Identity         | `recipe_id integer NOT NULL`, `item_id integer NOT NULL`, `stage integer NOT NULL`, `day integer NOT NULL`, `secretary integer NOT NULL`                                               |
+| Column group | Type and nullability |
+| --- | --- |
+| Primary key | `id bigint identity` |
+| Domain Identity | `recipe_id integer NOT NULL`, `item_id integer NOT NULL`, `stage integer NOT NULL`, `day integer NOT NULL`, `secretary integer NOT NULL` |
 | Nullable integer values | `fuel`, `ammo`, `steel`, `bauxite`, `req_item_id`, `req_item_count`, `buildkit`, `remodelkit`, `certain_buildkit`, `certain_remodelkit`, `upgrade_to_item_id`, `upgrade_to_item_level` |
-| Other values            | `key text NULL`, `origin text NULL`                                                                                                                                                    |
-| Accumulation            | `last_reported bigint NOT NULL`, `count bigint NOT NULL DEFAULT 1`                                                                                                                     |
+| Other values | `key text NULL`, `origin text NULL` |
+| Accumulation | `last_reported bigint NOT NULL`, `count bigint NOT NULL DEFAULT 1` |
 
 Unique `(recipe_id, item_id, stage, day, secretary)`. `stage === -1` remains a successful no-op.
 Insert with `count = 1`; on conflict increment `count`, set `last_reported` from database time, and
@@ -473,25 +473,25 @@ stored value; an explicit null does.
 
 `ship_stats`:
 
-| Column group    | Type and nullability                                                                                                                                                                                                  |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Primary key     | `id bigint identity`                                                                                                                                                                                                  |
+| Column group | Type and nullability |
+| --- | --- |
+| Primary key | `id bigint identity` |
 | Domain Identity | `ship_id integer NOT NULL`, `lv integer NOT NULL`, `los integer NOT NULL`, `los_max integer NOT NULL`, `asw integer NOT NULL`, `asw_max integer NOT NULL`, `evasion integer NOT NULL`, `evasion_max integer NOT NULL` |
-| Accumulation    | `last_timestamp bigint NOT NULL`, `count bigint NOT NULL DEFAULT 1`                                                                                                                                                   |
+| Accumulation | `last_timestamp bigint NOT NULL`, `count bigint NOT NULL DEFAULT 1` |
 
 Unique across the eight Domain Identity columns. Insert with `count = 1`; on conflict increment
 `count` and replace `last_timestamp` with database time.
 
 `enemy_infos`:
 
-| Column group             | Type and nullability                                                                                               |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------ |
-| Primary key              | `id bigint identity`                                                                                               |
-| Identity digest          | `identity_hash bytea NOT NULL`, exactly 32 bytes and unique                                                        |
-| Required flat arrays     | `ships1 integer[]`, `levels1 integer[]`, `hp1 integer[]`, `ships2 integer[]`, `levels2 integer[]`, `hp2 integer[]` |
-| Required nested arrays   | `stats1 jsonb`, `equips1 jsonb`, `stats2 jsonb`, `equips2 jsonb`                                                   |
-| Required scalar identity | `planes integer`                                                                                                   |
-| Accumulation             | `bombers_min integer NULL`, `bombers_max integer NULL`, `count bigint NOT NULL DEFAULT 1`                          |
+| Column group | Type and nullability |
+| --- | --- |
+| Primary key | `id bigint identity` |
+| Identity digest | `identity_hash bytea NOT NULL`, exactly 32 bytes and unique |
+| Required flat arrays | `ships1 integer[]`, `levels1 integer[]`, `hp1 integer[]`, `ships2 integer[]`, `levels2 integer[]`, `hp2 integer[]` |
+| Required nested arrays | `stats1 jsonb`, `equips1 jsonb`, `stats2 jsonb`, `equips2 jsonb` |
+| Required scalar identity | `planes integer` |
+| Accumulation | `bombers_min integer NULL`, `bombers_max integer NULL`, `count bigint NOT NULL DEFAULT 1` |
 
 All identity components are `NOT NULL`. Insert with `count = 1`. On conflict, verify component
 equality, increment `count`, update `bombers_min` to the greater non-null value, and update
@@ -507,36 +507,36 @@ encoding the equivalent PostgreSQL expressions.
 
 `quests`:
 
-| Column     | Type              | Contract                                           |
-| ---------- | ----------------- | -------------------------------------------------- |
-| `id`       | `bigint identity` | Primary key.                                       |
-| `key`      | `text`            | Not null; 32 lowercase hexadecimal MD5 characters. |
-| `quest_id` | `integer`         | Not null.                                          |
-| `title`    | `text`            | Not null.                                          |
-| `detail`   | `text`            | Not null.                                          |
-| `category` | `integer`         | Not null.                                          |
-| `type`     | `integer`         | Nullable.                                          |
-| `origin`   | `text`            | Nullable.                                          |
+| Column | Type | Contract |
+| --- | --- | --- |
+| `id` | `bigint identity` | Primary key. |
+| `key` | `text` | Not null; 32 lowercase hexadecimal MD5 characters. |
+| `quest_id` | `integer` | Not null. |
+| `title` | `text` | Not null. |
+| `detail` | `text` | Not null. |
+| `category` | `integer` | Not null. |
+| `type` | `integer` | Nullable. |
+| `origin` | `text` | Nullable. |
 
 Unique `(key, quest_id, category)`. On conflict, verify `title` and `detail` match and otherwise do
 nothing, preserving `$setOnInsert` behavior.
 
 `quest_rewards`:
 
-| Column        | Type              | Contract                                              |
-| ------------- | ----------------- | ----------------------------------------------------- |
-| `id`          | `bigint identity` | Primary key.                                          |
-| `key`         | `text`            | Not null; 32 lowercase hexadecimal MD5 characters.    |
-| `quest_id`    | `integer`         | Not null.                                             |
-| `title`       | `text`            | Not null.                                             |
-| `detail`      | `text`            | Not null.                                             |
-| `category`    | `integer`         | Nullable.                                             |
-| `type`        | `integer`         | Nullable.                                             |
-| `origin`      | `text`            | Nullable.                                             |
-| `selections`  | `integer[]`       | Not null.                                             |
-| `material`    | `integer[]`       | Nullable, default empty array.                        |
-| `bonus`       | `jsonb`           | Nullable, default JSON array `[]`.                    |
-| `bonus_count` | `integer`         | Not null; parsed from legacy HTTP field `bounsCount`. |
+| Column | Type | Contract |
+| --- | --- | --- |
+| `id` | `bigint identity` | Primary key. |
+| `key` | `text` | Not null; 32 lowercase hexadecimal MD5 characters. |
+| `quest_id` | `integer` | Not null. |
+| `title` | `text` | Not null. |
+| `detail` | `text` | Not null. |
+| `category` | `integer` | Nullable. |
+| `type` | `integer` | Nullable. |
+| `origin` | `text` | Nullable. |
+| `selections` | `integer[]` | Not null. |
+| `material` | `integer[]` | Nullable, default empty array. |
+| `bonus` | `jsonb` | Nullable, default JSON array `[]`. |
+| `bonus_count` | `integer` | Not null; parsed from legacy HTTP field `bounsCount`. |
 
 Unique `(key, quest_id, selections, bonus_count)`. On conflict, verify `title` and `detail` match and
 otherwise do nothing.
@@ -545,24 +545,24 @@ otherwise do nothing.
 
 Create one shared sequence, `item_improvement_fact_id_seq`. Every Fact table has:
 
-| Column                     | Type        | Contract                                                                                                           |
-| -------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------ |
-| `id`                       | `bigint`    | Primary key, default `nextval('item_improvement_fact_id_seq')`.                                                    |
-| `export_id`                | `text`      | Stored generated value `lpad(to_hex(id), 24, '0')`; unique and constrained to 24 lowercase hexadecimal characters. |
-| `key`                      | `text`      | Not null and unique.                                                                                               |
-| `schema_version`           | `integer`   | Not null.                                                                                                          |
-| `recipe_id`                | `integer`   | Not null.                                                                                                          |
-| `item_id`                  | `integer`   | Not null.                                                                                                          |
-| `day`                      | `integer`   | Not null.                                                                                                          |
-| `first_client_observed_at` | `bigint`    | Not null.                                                                                                          |
-| `last_client_observed_at`  | `bigint`    | Not null.                                                                                                          |
-| `observed_second_ship_id`  | `integer`   | Not null.                                                                                                          |
-| `observed_flagship_ids`    | `integer[]` | Not null, default empty array.                                                                                     |
-| `sources`                  | `text[]`    | Not null, default empty array.                                                                                     |
-| `origins`                  | `text[]`    | Not null, default empty array; private in exports.                                                                 |
-| `first_reported`           | `bigint`    | Not null.                                                                                                          |
-| `last_reported`            | `bigint`    | Not null.                                                                                                          |
-| `count`                    | `bigint`    | Not null, default `1`.                                                                                             |
+| Column | Type | Contract |
+| --- | --- | --- |
+| `id` | `bigint` | Primary key, default `nextval('item_improvement_fact_id_seq')`. |
+| `export_id` | `text` | Stored generated value `lpad(to_hex(id), 24, '0')`; unique and constrained to 24 lowercase hexadecimal characters. |
+| `key` | `text` | Not null and unique. |
+| `schema_version` | `integer` | Not null. |
+| `recipe_id` | `integer` | Not null. |
+| `item_id` | `integer` | Not null. |
+| `day` | `integer` | Not null. |
+| `first_client_observed_at` | `bigint` | Not null. |
+| `last_client_observed_at` | `bigint` | Not null. |
+| `observed_second_ship_id` | `integer` | Not null. |
+| `observed_flagship_ids` | `integer[]` | Not null, default empty array. |
+| `sources` | `text[]` | Not null, default empty array. |
+| `origins` | `text[]` | Not null, default empty array; private in exports. |
+| `first_reported` | `bigint` | Not null. |
+| `last_reported` | `bigint` | Not null. |
+| `count` | `bigint` | Not null, default `1`. |
 
 `item_improvement_availability_facts` adds no other columns.
 
@@ -658,16 +658,16 @@ interface CommunityDumpManifestV1 {
 
 Community Dump record schema version 1 uses these JSON keys in this exact order:
 
-| Dataset                     | Ordered keys after `observationId`, `ingestedAt`                                                                                                                                                                  |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `createShipObservations`    | `items`, `kdockId`, `secretary`, `shipId`, `highspeed`, `teitokuLv`, `largeFlag`, `origin`                                                                                                                        |
-| `createItemObservations`    | `items`, `secretary`, `itemId`, `teitokuLv`, `successful`, `origin`                                                                                                                                               |
-| `remodelItemObservations`   | `successful`, `itemId`, `itemLevel`, `flagshipId`, `flagshipLevel`, `flagshipCond`, `consortId`, `consortLevel`, `consortCond`, `teitokuLv`, `certain`                                                            |
-| `dropShipObservations`      | `shipId`, `itemId`, `mapId`, `quest`, `cellId`, `enemy`, `rank`, `isBoss`, `teitokuLv`, `mapLv`, `enemyShips1`, `enemyShips2`, `enemyFormation`, `baseExp`, `teitokuId`, `ownedShipSnapshot`, `origin`            |
-| `passEventObservations`     | `teitokuId`, `teitokuLv`, `mapId`, `mapLv`, `rewards`, `origin`                                                                                                                                                   |
-| `battleApiObservations`     | `origin`, `path`, `data`                                                                                                                                                                                          |
-| `nightContactObservations`  | `fleetType`, `shipId`, `shipLv`, `itemId`, `itemLv`, `contact`                                                                                                                                                    |
-| `aaciObservations`          | `poiVersion`, `available`, `triggered`, `items`, `improvement`, `rawLuck`, `rawTaiku`, `lv`, `hpPercent`, `pos`, `origin`                                                                                         |
+| Dataset | Ordered keys after `observationId`, `ingestedAt` |
+| --- | --- |
+| `createShipObservations` | `items`, `kdockId`, `secretary`, `shipId`, `highspeed`, `teitokuLv`, `largeFlag`, `origin` |
+| `createItemObservations` | `items`, `secretary`, `itemId`, `teitokuLv`, `successful`, `origin` |
+| `remodelItemObservations` | `successful`, `itemId`, `itemLevel`, `flagshipId`, `flagshipLevel`, `flagshipCond`, `consortId`, `consortLevel`, `consortCond`, `teitokuLv`, `certain` |
+| `dropShipObservations` | `shipId`, `itemId`, `mapId`, `quest`, `cellId`, `enemy`, `rank`, `isBoss`, `teitokuLv`, `mapLv`, `enemyShips1`, `enemyShips2`, `enemyFormation`, `baseExp`, `teitokuId`, `ownedShipSnapshot`, `origin` |
+| `passEventObservations` | `teitokuId`, `teitokuLv`, `mapId`, `mapLv`, `rewards`, `origin` |
+| `battleApiObservations` | `origin`, `path`, `data` |
+| `nightContactObservations` | `fleetType`, `shipId`, `shipLv`, `itemId`, `itemLv`, `contact` |
+| `aaciObservations` | `poiVersion`, `available`, `triggered`, `items`, `improvement`, `rawLuck`, `rawTaiku`, `lv`, `hpPercent`, `pos`, `origin` |
 | `nightBattleCiObservations` | `shipId`, `CI`, `type`, `lv`, `rawLuck`, `pos`, `status`, `items`, `improvement`, `searchLight`, `flare`, `defenseId`, `defenseTypeId`, `ciType`, `display`, `hitType`, `damage`, `damageTotal`, `time`, `origin` |
 
 Serialization rules:
@@ -748,15 +748,15 @@ Important indexes and constraints:
 
 Concrete PostgreSQL upsert keys:
 
-| Table                  | Upsert/uniqueness key                                                                                                                                                                                                                                                 |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `select_rank_records`  | `(teitoku_id, maparea_id)`                                                                                                                                                                                                                                            |
-| `recipe_records`       | `(recipe_id, item_id, stage, day, secretary)`                                                                                                                                                                                                                         |
-| `ship_stats`           | `(ship_id, lv, los, los_max, asw, asw_max, evasion, evasion_max)`                                                                                                                                                                                                     |
-| `enemy_infos`          | SHA-256 of an ordered JSON tuple containing `ships1`, `levels1`, `hp1`, `stats1`, `equips1`, `ships2`, `levels2`, `hp2`, `stats2`, `equips2`, and `planes`.                                                                                                           |
-| `quests`               | `(key, quest_id, category)`                                                                                                                                                                                                                                           |
-| `quest_rewards`        | `(key, quest_id, selections, bonus_count)` using PostgreSQL's native equality support for primitive array columns. The PostgreSQL column should use the corrected `bonus_count` name while the HTTP payload parser continues accepting the legacy `bounsCount` field. |
-| item-improvement facts | `key`                                                                                                                                                                                                                                                                 |
+| Table | Upsert/uniqueness key |
+| --- | --- |
+| `select_rank_records` | `(teitoku_id, maparea_id)` |
+| `recipe_records` | `(recipe_id, item_id, stage, day, secretary)` |
+| `ship_stats` | `(ship_id, lv, los, los_max, asw, asw_max, evasion, evasion_max)` |
+| `enemy_infos` | SHA-256 of an ordered JSON tuple containing `ships1`, `levels1`, `hp1`, `stats1`, `equips1`, `ships2`, `levels2`, `hp2`, `stats2`, `equips2`, and `planes`. |
+| `quests` | `(key, quest_id, category)` |
+| `quest_rewards` | `(key, quest_id, selections, bonus_count)` using PostgreSQL's native equality support for primitive array columns. The PostgreSQL column should use the corrected `bonus_count` name while the HTTP payload parser continues accepting the legacy `bounsCount` field. |
+| item-improvement facts | `key` |
 
 These tuples are Domain Identities, not migration identifiers. Enforce each Domain Identity with a
 unique constraint so concurrent writes use one atomic `INSERT ... ON CONFLICT ... DO UPDATE` path
@@ -783,22 +783,22 @@ Enemy Info identity hashing must exactly preserve MongoDB's current equality sem
 
 ## Semantic mapping
 
-| Current MongoDB semantic                                   | PostgreSQL/Drizzle design                                                                                                               |
-| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `new Model(info).save()`                                   | Validate and map declared fields explicitly, discard undeclared fields, and insert typed/declared JSONB columns                         |
-| status `count()`                                           | MongoDB metadata estimate or PostgreSQL catalog estimate; exact counts are reserved for offline dump verification                       |
-| `distinct('questId')`                                      | A Drizzle distinct projection such as `selectDistinct({ questId: table.questId }).from(table)`; preserve current endpoint sort behavior |
-| `findOne` then mutate/save for select rank                 | Unique key on `(teitoku_id, maparea_id)` with conflict update                                                                           |
-| `$setOnInsert`                                             | Conflict update with immutable insert-only fields omitted from the update set                                                           |
-| `$inc`                                                     | `count = table.count + 1`                                                                                                               |
-| `$min`                                                     | `first_client_observed_at = least(existing, excluded)`                                                                                  |
-| `$max`                                                     | `last_reported = greatest(existing, excluded)` and same for client observed timestamp                                                   |
-| `$addToSet` scalar or `$each` arrays                       | PostgreSQL stable append-if-absent union that preserves existing order                                                                  |
-| Mongoose ObjectId export cursor                            | Shared-sequence bigint encoded as a stored 24-character lowercase hexadecimal `export_id`                                               |
-| `.select('-__v -origins')`                                 | Explicit selected column list that excludes `origins` and maps internal `export_id` to public `_id`                                     |
-| `.sort({ lastReported: 1, _id: 1 })`                       | `orderBy(last_reported asc, export_id asc)`                                                                                             |
-| Flexible nested Mongo fields                               | JSONB fields for payloads or snapshots that are not queried structurally                                                                |
-| `EnemyInfo` `$max: { bombersMin }`, `$min: { bombersMax }` | Presence-aware PostgreSQL expressions that reproduce the tested MongoDB numeric/null transitions                                        |
+| Current MongoDB semantic | PostgreSQL/Drizzle design |
+| --- | --- |
+| `new Model(info).save()` | Validate and map declared fields explicitly, discard undeclared fields, and insert typed/declared JSONB columns |
+| status `count()` | MongoDB metadata estimate or PostgreSQL catalog estimate; exact counts are reserved for offline dump verification |
+| `distinct('questId')` | A Drizzle distinct projection such as `selectDistinct({ questId: table.questId }).from(table)`; preserve current endpoint sort behavior |
+| `findOne` then mutate/save for select rank | Unique key on `(teitoku_id, maparea_id)` with conflict update |
+| `$setOnInsert` | Conflict update with immutable insert-only fields omitted from the update set |
+| `$inc` | `count = table.count + 1` |
+| `$min` | `first_client_observed_at = least(existing, excluded)` |
+| `$max` | `last_reported = greatest(existing, excluded)` and same for client observed timestamp |
+| `$addToSet` scalar or `$each` arrays | PostgreSQL stable append-if-absent union that preserves existing order |
+| Mongoose ObjectId export cursor | Shared-sequence bigint encoded as a stored 24-character lowercase hexadecimal `export_id` |
+| `.select('-__v -origins')` | Explicit selected column list that excludes `origins` and maps internal `export_id` to public `_id` |
+| `.sort({ lastReported: 1, _id: 1 })` | `orderBy(last_reported asc, export_id asc)` |
+| Flexible nested Mongo fields | JSONB fields for payloads or snapshots that are not queried structurally |
+| `EnemyInfo` `$max: { bombersMin }`, `$min: { bombersMax }` | Presence-aware PostgreSQL expressions that reproduce the tested MongoDB numeric/null transitions |
 
 ## v3 item-improvement compatibility
 
@@ -913,50 +913,50 @@ The same HTTP behavior suite should run against both backends where possible.
 
 The test contract matrix maps behavior to required MongoDB and PostgreSQL assertions:
 
-| Area                        | Required parity coverage                                                                                                                                                                                                                                              |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Backend config              | URI scheme selects MongoDB or PostgreSQL; unsupported schemes fail with redacted errors.                                                                                                                                                                              |
-| `/api/status`               | Both backends return the same backend-neutral `database` shape; the legacy `mongo` field is absent.                                                                                                                                                                   |
-| v2 observations             | Each report endpoint persists the declared fields and discards undeclared fields consistently on both backends.                                                                                                                                                       |
-| v2 upserts                  | `select_rank`, `remodel_recipe`, `ship_stat`, and `enemy_info` match current update behavior, including Enemy Info absent/null/numeric bomber transitions.                                                                                                            |
-| v2 compatibility routes     | `known_quests`, `known_recipes`, `quest/:id`, `remodel_recipe_deduplicate`, and `night_battle_ss_ci` keep current response behavior.                                                                                                                                  |
-| v3 quests                   | Quest and reward keys, uniqueness, known quest prefixes, and legacy `bounsCount` payload handling match MongoDB behavior.                                                                                                                                             |
-| v3 item-improvement ingest  | Keys, normalization, `$setOnInsert` equivalents, min/max timestamps, stable append-if-absent arrays, origins, and counts match MongoDB behavior.                                                                                                                      |
-| v3 item-improvement export  | Both backends cover limit clamping, origin omission, numeric timestamps, public `_id`, cursor canonicalization, ordering, and empty pages; PostgreSQL additionally covers database-time settled pagination.                                                           |
-| Monthly dumps and retention | All nine versioned JSONL serializers, manifest/object read-back verification, default-partition repair, grace period, catalog-bound partition verification, and cleanup classifications pass.                                                                         |
-| Error handling              | Malformed JSON, invalid payloads, invalid cursors, and database errors preserve current status/body behavior.                                                                                                                                                         |
-| Shared validation           | Both backends preserve documented Mongoose casting/defaults, enforce int32/safe-bigint ranges, reject cast failures, missing Domain Identity, invalid AACI semver, or fractional integral fields with the same 400 body, and emit bounded structured validation logs. |
+| Area | Required parity coverage |
+| --- | --- |
+| Backend config | URI scheme selects MongoDB or PostgreSQL; unsupported schemes fail with redacted errors. |
+| `/api/status` | Both backends return the same backend-neutral `database` shape; the legacy `mongo` field is absent. |
+| v2 observations | Each report endpoint persists the declared fields and discards undeclared fields consistently on both backends. |
+| v2 upserts | `select_rank`, `remodel_recipe`, `ship_stat`, and `enemy_info` match current update behavior, including Enemy Info absent/null/numeric bomber transitions. |
+| v2 compatibility routes | `known_quests`, `known_recipes`, `quest/:id`, `remodel_recipe_deduplicate`, and `night_battle_ss_ci` keep current response behavior. |
+| v3 quests | Quest and reward keys, uniqueness, known quest prefixes, and legacy `bounsCount` payload handling match MongoDB behavior. |
+| v3 item-improvement ingest | Keys, normalization, `$setOnInsert` equivalents, min/max timestamps, stable append-if-absent arrays, origins, and counts match MongoDB behavior. |
+| v3 item-improvement export | Both backends cover limit clamping, origin omission, numeric timestamps, public `_id`, cursor canonicalization, ordering, and empty pages; PostgreSQL additionally covers database-time settled pagination. |
+| Monthly dumps and retention | All nine versioned JSONL serializers, manifest/object read-back verification, default-partition repair, grace period, catalog-bound partition verification, and cleanup classifications pass. |
+| Error handling | Malformed JSON, invalid payloads, invalid cursors, and database errors preserve current status/body behavior. |
+| Shared validation | Both backends preserve documented Mongoose casting/defaults, enforce int32/safe-bigint ranges, reject cast failures, missing Domain Identity, invalid AACI semver, or fractional integral fields with the same 400 body, and emit bounded structured validation logs. |
 
 Endpoint-level required cases:
 
-| Endpoint                                                   | Required behavior assertions on both backends                                                                                                                                 |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `POST /api/report/v2/create_ship`                          | Declared fields persist once; omitted arrays become empty; unknown fields are discarded.                                                                                      |
-| `POST /api/report/v2/create_item`                          | Declared fields persist once with shared casting and integer validation.                                                                                                      |
-| `POST /api/report/v2/remodel_item`                         | Declared fields persist once; injected `origin` is discarded because it is not in the legacy schema.                                                                          |
-| `POST /api/report/v2/drop_ship`                            | `ownedShipSnapshot` becomes `{}` for `mapId < 73`; otherwise declared JSON is retained.                                                                                       |
-| `POST /api/report/v2/select_rank`                          | Repeated Domain Identity replaces current level/rank/origin and does not add a second row.                                                                                    |
-| `POST /api/report/v2/pass_event`                           | Declared reward objects persist in order; omitted rewards normalize to an empty array.                                                                                        |
-| `GET /api/report/v2/known_quests`                          | Returns distinct quest IDs with the current JavaScript default sort behavior and Cloudflare cache headers.                                                                    |
-| `POST /api/report/v2/quest/:id`                            | Returns 200 and performs no write.                                                                                                                                            |
-| `POST /api/report/v2/battle_api`                           | Declared `path`, `origin`, and arbitrary JSON `data` persist; unknown top-level fields are discarded.                                                                         |
-| `POST /api/report/v2/night_contcat`                        | Misspelled route remains registered; declared fields persist; injected `origin` is discarded.                                                                                 |
-| `POST /api/report/v2/aaci`                                 | Invalid/missing semantic versions return logged 400; writes only when all current POI/reporter version gates pass; all other valid reports return 200 without a write.        |
-| `GET /api/report/v2/known_recipes`                         | Returns `{ recipes: [] }`.                                                                                                                                                    |
-| `POST /api/report/v2/remodel_recipe`                       | `stage === -1` is a no-op; otherwise insert/count/update semantics follow the exact Aggregate contract.                                                                       |
-| `POST /api/report/v2/remodel_recipe_deduplicate`           | MongoDB removes legacy duplicates; PostgreSQL normally returns an empty deletion list because Domain Identity is unique.                                                      |
-| `POST /api/report/v2/night_battle_ci`                      | Fractional `damage` and `damageTotal` round-trip; millisecond `time` remains a JSON number.                                                                                   |
-| `POST /api/report/v2/night_battle_ss_ci`                   | Returns 200 and performs no write.                                                                                                                                            |
-| `POST /api/report/v2/ship_stat`                            | Domain Identity inserts once, then atomically increments count and advances `last_timestamp`.                                                                                 |
-| `POST /api/report/v2/enemy_info`                           | Ordered identity hashing matches Mongo tuple equality; count increments; min/max null and intersection rules match.                                                           |
-| `POST /api/report/v3/item_improvement_recipe`              | Single and batch forms normalize identically; maximum batch 100; partial-write behavior on database failure matches the current per-record writes; response count is correct. |
-| `GET /api/report/v3/item_improvement_recipes/availability` | Filters, clamp, public `_id`, cursor, omission of origins, and cache headers match; PostgreSQL alone applies the settled window.                                              |
-| `GET /api/report/v3/item_improvement_recipes/costs`        | Same backend-aware export contract plus required-item JSON round-trip and stable arrays.                                                                                      |
-| `GET /api/report/v3/item_improvement_recipes/updates`      | Same backend-aware export contract plus upgrade fields.                                                                                                                       |
-| `GET /api/report/v3/known_quests`                          | Returns distinct eight-character quest-key prefixes with Cloudflare cache headers.                                                                                            |
-| `POST /api/report/v3/quest`                                | Every quest in the Report uses MD5 title/detail keying and insert-only Definition semantics.                                                                                  |
-| `POST /api/report/v3/quest_reward`                         | Accepts legacy `bounsCount`, stores `bonus_count`, preserves material/bonus structures, and inserts only once per Domain Identity.                                            |
-| `GET /api/status`                                          | Returns `env`, `disk`, and the exact backend-neutral `database` shape with all 18 estimated counts.                                                                           |
+| Endpoint | Required behavior assertions on both backends |
+| --- | --- |
+| `POST /api/report/v2/create_ship` | Declared fields persist once; omitted arrays become empty; unknown fields are discarded. |
+| `POST /api/report/v2/create_item` | Declared fields persist once with shared casting and integer validation. |
+| `POST /api/report/v2/remodel_item` | Declared fields persist once; injected `origin` is discarded because it is not in the legacy schema. |
+| `POST /api/report/v2/drop_ship` | `ownedShipSnapshot` becomes `{}` for `mapId < 73`; otherwise declared JSON is retained. |
+| `POST /api/report/v2/select_rank` | Repeated Domain Identity replaces current level/rank/origin and does not add a second row. |
+| `POST /api/report/v2/pass_event` | Declared reward objects persist in order; omitted rewards normalize to an empty array. |
+| `GET /api/report/v2/known_quests` | Returns distinct quest IDs with the current JavaScript default sort behavior and Cloudflare cache headers. |
+| `POST /api/report/v2/quest/:id` | Returns 200 and performs no write. |
+| `POST /api/report/v2/battle_api` | Declared `path`, `origin`, and arbitrary JSON `data` persist; unknown top-level fields are discarded. |
+| `POST /api/report/v2/night_contcat` | Misspelled route remains registered; declared fields persist; injected `origin` is discarded. |
+| `POST /api/report/v2/aaci` | Invalid/missing semantic versions return logged 400; writes only when all current POI/reporter version gates pass; all other valid reports return 200 without a write. |
+| `GET /api/report/v2/known_recipes` | Returns `{ recipes: [] }`. |
+| `POST /api/report/v2/remodel_recipe` | `stage === -1` is a no-op; otherwise insert/count/update semantics follow the exact Aggregate contract. |
+| `POST /api/report/v2/remodel_recipe_deduplicate` | MongoDB removes legacy duplicates; PostgreSQL normally returns an empty deletion list because Domain Identity is unique. |
+| `POST /api/report/v2/night_battle_ci` | Fractional `damage` and `damageTotal` round-trip; millisecond `time` remains a JSON number. |
+| `POST /api/report/v2/night_battle_ss_ci` | Returns 200 and performs no write. |
+| `POST /api/report/v2/ship_stat` | Domain Identity inserts once, then atomically increments count and advances `last_timestamp`. |
+| `POST /api/report/v2/enemy_info` | Ordered identity hashing matches Mongo tuple equality; count increments; min/max null and intersection rules match. |
+| `POST /api/report/v3/item_improvement_recipe` | Single and batch forms normalize identically; maximum batch 100; partial-write behavior on database failure matches the current per-record writes; response count is correct. |
+| `GET /api/report/v3/item_improvement_recipes/availability` | Filters, clamp, public `_id`, cursor, omission of origins, and cache headers match; PostgreSQL alone applies the settled window. |
+| `GET /api/report/v3/item_improvement_recipes/costs` | Same backend-aware export contract plus required-item JSON round-trip and stable arrays. |
+| `GET /api/report/v3/item_improvement_recipes/updates` | Same backend-aware export contract plus upgrade fields. |
+| `GET /api/report/v3/known_quests` | Returns distinct eight-character quest-key prefixes with Cloudflare cache headers. |
+| `POST /api/report/v3/quest` | Every quest in the Report uses MD5 title/detail keying and insert-only Definition semantics. |
+| `POST /api/report/v3/quest_reward` | Accepts legacy `bounsCount`, stores `bonus_count`, preserves material/bonus structures, and inserts only once per Domain Identity. |
+| `GET /api/status` | Returns `env`, `disk`, and the exact backend-neutral `database` shape with all 18 estimated counts. |
 
 Implementation is not complete until the parity matrix passes against MongoDB and a real PostgreSQL
 service in CI. PGlite-only coverage is insufficient for accepting the PostgreSQL backend.

--- a/docs/report-data.md
+++ b/docs/report-data.md
@@ -1,0 +1,146 @@
+# Report data catalog
+
+This document describes the report data currently persisted by poi-server. It is a readable snapshot,
+not the source of truth for a permanent dataset count.
+
+The authoritative implementation sources are:
+
+- [`CONTEXT.md`](../CONTEXT.md) for the meanings of Observation, Current State, Aggregate, Definition,
+  and Item-improvement Fact;
+- [`src/dumps/community-dump-registry.ts`](../src/dumps/community-dump-registry.ts) for the datasets
+  included in Community Dumps;
+- [`src/db/postgres/schema.ts`](../src/db/postgres/schema.ts) for PostgreSQL storage;
+- [`src/contracts/database.ts`](../src/contracts/database.ts) for the dataset names exposed by
+  `/api/status`.
+
+The current status catalog contains 18 report datasets:
+
+| Classification        | Current count | Monthly partitioned | Removed after verified dump |
+| --------------------- | ------------: | ------------------- | --------------------------- |
+| Observation Dataset   |             9 | Yes                 | Yes                         |
+| Current State         |             1 | No                  | No                          |
+| Aggregate             |             3 | No                  | No                          |
+| Definition            |             2 | No                  | No                          |
+| Item-improvement Fact |             3 | No                  | No                          |
+
+These counts describe the current model and are not permanent limits.
+
+## Why there are currently nine monthly partitions
+
+A PostgreSQL partition belongs to one parent table. For each Dump Month, poi-server creates one
+monthly child partition for every Observation dataset registered for Community Dumps.
+
+The registry currently contains nine Observation datasets, so one month currently has nine child
+partitions:
+
+```text
+one Dump Month x nine registered Observation parent tables = nine monthly child partitions
+```
+
+This does **not** mean nine months are created. During July, for example, scheduled maintenance
+ensures that each registered parent table has its August child partition. The number nine is only the
+current dataset count; it can change when the report model, dump registry, and database schema are
+changed together.
+
+Only Observations use monthly partitions and the verified dump-retention cleanup path. Current State,
+Aggregate, Definition, and Item-improvement Fact data remains in its regular tables.
+
+## Partitioned Observation datasets
+
+Every accepted Observation is retained independently. Each table is range-partitioned by
+`ingested_at` using JST Dump Month boundaries and has a default partition as a safety net.
+
+| Community Dump dataset      | PostgreSQL parent table | Report endpoint                       | What it records                                                          |
+| --------------------------- | ----------------------- | ------------------------------------- | ------------------------------------------------------------------------ |
+| `createShipObservations`    | `create_ship_records`   | `POST /api/report/v2/create_ship`     | A ship-construction result and its construction context.                 |
+| `createItemObservations`    | `create_item_records`   | `POST /api/report/v2/create_item`     | An equipment-development attempt, including success and result.          |
+| `remodelItemObservations`   | `remodel_item_records`  | `POST /api/report/v2/remodel_item`    | An equipment-remodeling attempt and the participating ship context.      |
+| `dropShipObservations`      | `drop_ship_records`     | `POST /api/report/v2/drop_ship`       | A ship or item drop outcome with map, battle, enemy, and player context. |
+| `passEventObservations`     | `pass_event_records`    | `POST /api/report/v2/pass_event`      | An event-map completion and its rewards.                                 |
+| `battleApiObservations`     | `battle_apis`           | `POST /api/report/v2/battle_api`      | A reported battle API path and raw payload.                              |
+| `nightContactObservations`  | `night_contacts`        | `POST /api/report/v2/night_contcat`   | A night-contact result with fleet, ship, and equipment context.          |
+| `aaciObservations`          | `aaci_records`          | `POST /api/report/v2/aaci`            | An anti-air cut-in availability and trigger result.                      |
+| `nightBattleCiObservations` | `night_battle_cis`      | `POST /api/report/v2/night_battle_ci` | A night-battle cut-in result, including activation and damage details.   |
+
+The `night_contcat` route spelling is a retained legacy API contract.
+
+For a target month such as `2026-08`, the corresponding child tables use names such as
+`create_ship_records_2026_08`, `create_item_records_2026_08`, and one equivalent child name for every
+other registered Observation parent.
+
+Each Community Dump publishes one compressed JSON Lines object per registered dataset. After
+publication, object verification, and the cleanup grace period, cleanup detaches and drops only that
+month's verified Observation child partitions.
+
+Every dumped row starts with `observationId` and `ingestedAt`; the dataset-specific fields are defined
+in the Community Dump registry.
+
+## Non-partitioned report data
+
+These datasets are exposed in `/api/status.database.estimatedCounts`, but they are not monthly
+Observation partitions and are not removed by Community Dump cleanup.
+
+### Current State
+
+| Status dataset     | PostgreSQL table      | Report endpoint                   | What it retains                                                  |
+| ------------------ | --------------------- | --------------------------------- | ---------------------------------------------------------------- |
+| `selectRankStates` | `select_rank_records` | `POST /api/report/v2/select_rank` | The latest selected map difficulty for each player and map area. |
+
+### Aggregates
+
+Repeated reports matching the same Domain Identity update one durable summary rather than creating
+monthly Observation rows.
+
+| Status dataset        | PostgreSQL table | Report endpoint                      | What it combines                                                      |
+| --------------------- | ---------------- | ------------------------------------ | --------------------------------------------------------------------- |
+| `recipeAggregates`    | `recipe_records` | `POST /api/report/v2/remodel_recipe` | Repeated reports of the same equipment-improvement recipe.            |
+| `shipStatAggregates`  | `ship_stats`     | `POST /api/report/v2/ship_stat`      | Repeated reports of the same ship-level stat values.                  |
+| `enemyInfoAggregates` | `enemy_infos`    | `POST /api/report/v2/enemy_info`     | Repeated sightings of the same enemy fleet composition and equipment. |
+
+### Definitions
+
+Definitions deduplicate descriptions of known game concepts.
+
+| Status dataset           | PostgreSQL table | Report endpoint                    | What it defines                                                 |
+| ------------------------ | ---------------- | ---------------------------------- | --------------------------------------------------------------- |
+| `questDefinitions`       | `quests`         | `POST /api/report/v3/quest`        | Quest identity, title, detail, category, and type.              |
+| `questRewardDefinitions` | `quest_rewards`  | `POST /api/report/v3/quest_reward` | A quest reward configuration, including selections and bonuses. |
+
+### Item-improvement Facts
+
+`POST /api/report/v3/item_improvement_recipe` normalizes submitted records into one or more Fact
+types. Repeated support strengthens the matching Fact by updating timestamps, sources, origins,
+observed flagship IDs, and report count.
+
+| Status dataset                     | PostgreSQL table                      | Export endpoint                                            | What it claims                                                           |
+| ---------------------------------- | ------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `itemImprovementAvailabilityFacts` | `item_improvement_availability_facts` | `GET /api/report/v3/item_improvement_recipes/availability` | When an item-improvement recipe is available and which ships support it. |
+| `itemImprovementCostFacts`         | `item_improvement_cost_facts`         | `GET /api/report/v3/item_improvement_recipes/costs`        | Resource and material costs for an item-improvement stage.               |
+| `itemImprovementUpdateFacts`       | `item_improvement_update_facts`       | `GET /api/report/v3/item_improvement_recipes/updates`      | The upgraded item and resulting level produced by an improvement.        |
+
+## Internal dump metadata
+
+`data_dump_runs` and `data_dump_files` track publication status, manifests, object verification, and
+the exact partition names used by cleanup. They are operational metadata, not report datasets and not
+part of `/api/status.database.estimatedCounts`.
+
+## Report endpoints without persisted report data
+
+Some retained API routes intentionally do not add a dataset:
+
+- `POST /api/report/v2/quest/:id` returns success without writing.
+- `GET /api/report/v2/known_recipes` returns an empty recipe list.
+- `POST /api/report/v2/night_battle_ss_ci` returns success without writing.
+- `POST /api/report/v2/remodel_recipe_deduplicate` is maintenance for legacy MongoDB duplicates; it
+  does not define another PostgreSQL report dataset.
+
+## Updating this catalog
+
+When report data changes:
+
+1. Classify the data using the language in `CONTEXT.md`.
+2. Add it to the Community Dump registry only if it is an independently retained Observation meant
+   for monthly publication and retention cleanup.
+3. Update the PostgreSQL schema, status count contract, migrations, tests, and this catalog together.
+4. Describe partition counts as the current registry size, never as a permanent architectural
+   constant.

--- a/drizzle/0002_canonical_dump_month.sql
+++ b/drizzle/0002_canonical_dump_month.sql
@@ -1,0 +1,15 @@
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "data_dump_runs"
+    GROUP BY "dump_month"
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'Cannot enforce one canonical data_dump_runs row per dump_month while duplicate months exist';
+  END IF;
+END
+$$;--> statement-breakpoint
+ALTER TABLE "data_dump_runs" DROP CONSTRAINT "data_dump_runs_month_version_key";--> statement-breakpoint
+ALTER TABLE "data_dump_runs" ADD CONSTRAINT "data_dump_runs_month_key" UNIQUE("dump_month");--> statement-breakpoint
+UPDATE "schema_metadata" SET "version" = 3 WHERE "singleton" = true;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,2592 @@
+{
+  "id": "4df0f45c-0a0f-4a1b-9cb6-a112affe3263",
+  "prevId": "16a9b8c2-4818-41ce-86ce-87a897b3464c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.aaci_records": {
+      "name": "aaci_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "aaci_records_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "poi_version": {
+          "name": "poi_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available": {
+          "name": "available",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "triggered": {
+          "name": "triggered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "items": {
+          "name": "items",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "improvement": {
+          "name": "improvement",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "raw_luck": {
+          "name": "raw_luck",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_taiku": {
+          "name": "raw_taiku",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lv": {
+          "name": "lv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hp_percent": {
+          "name": "hp_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pos": {
+          "name": "pos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "aaci_records_ingested_at_id_pk": {
+          "name": "aaci_records_ingested_at_id_pk",
+          "columns": ["ingested_at", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.battle_apis": {
+      "name": "battle_apis",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "battle_apis_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "battle_apis_ingested_at_id_pk": {
+          "name": "battle_apis_ingested_at_id_pk",
+          "columns": ["ingested_at", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.create_item_records": {
+      "name": "create_item_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "create_item_records_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "items": {
+          "name": "items",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "secretary": {
+          "name": "secretary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teitoku_lv": {
+          "name": "teitoku_lv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successful": {
+          "name": "successful",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "create_item_records_ingested_at_id_pk": {
+          "name": "create_item_records_ingested_at_id_pk",
+          "columns": ["ingested_at", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.create_ship_records": {
+      "name": "create_ship_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "create_ship_records_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "items": {
+          "name": "items",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "kdock_id": {
+          "name": "kdock_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secretary": {
+          "name": "secretary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ship_id": {
+          "name": "ship_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highspeed": {
+          "name": "highspeed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teitoku_lv": {
+          "name": "teitoku_lv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "large_flag": {
+          "name": "large_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "create_ship_records_ingested_at_id_pk": {
+          "name": "create_ship_records_ingested_at_id_pk",
+          "columns": ["ingested_at", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_dump_files": {
+      "name": "data_dump_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "data_dump_files_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "dump_run_id": {
+          "name": "dump_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset": {
+          "name": "dataset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partition_name": {
+          "name": "partition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compressed_bytes": {
+          "name": "compressed_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "data_dump_files_dump_run_id_data_dump_runs_id_fk": {
+          "name": "data_dump_files_dump_run_id_data_dump_runs_id_fk",
+          "tableFrom": "data_dump_files",
+          "tableTo": "data_dump_runs",
+          "columnsFrom": ["dump_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_dump_files_dump_run_dataset_key": {
+          "name": "data_dump_files_dump_run_dataset_key",
+          "nullsNotDistinct": false,
+          "columns": ["dump_run_id", "dataset"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "data_dump_files_dataset_check": {
+          "name": "data_dump_files_dataset_check",
+          "value": "\"data_dump_files\".\"dataset\" in ('createShipObservations', 'createItemObservations', 'remodelItemObservations', 'dropShipObservations', 'passEventObservations', 'battleApiObservations', 'nightContactObservations', 'aaciObservations', 'nightBattleCiObservations')"
+        },
+        "data_dump_files_row_count_nonnegative": {
+          "name": "data_dump_files_row_count_nonnegative",
+          "value": "\"data_dump_files\".\"row_count\" >= 0"
+        },
+        "data_dump_files_compressed_bytes_nonnegative": {
+          "name": "data_dump_files_compressed_bytes_nonnegative",
+          "value": "\"data_dump_files\".\"compressed_bytes\" >= 0"
+        },
+        "data_dump_files_sha256_length": {
+          "name": "data_dump_files_sha256_length",
+          "value": "octet_length(\"data_dump_files\".\"sha256\") = 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.data_dump_runs": {
+      "name": "data_dump_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "data_dump_runs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "dump_month": {
+          "name": "dump_month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_object_key": {
+          "name": "manifest_object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_bytes": {
+          "name": "manifest_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_sha256": {
+          "name": "manifest_sha256",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_eligible_at": {
+          "name": "cleanup_eligible_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleaned_at": {
+          "name": "cleaned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_dump_runs_month_key": {
+          "name": "data_dump_runs_month_key",
+          "nullsNotDistinct": false,
+          "columns": ["dump_month"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "data_dump_runs_status_check": {
+          "name": "data_dump_runs_status_check",
+          "value": "\"data_dump_runs\".\"status\" in ('pending', 'exporting', 'uploaded', 'published', 'cleanup_eligible', 'cleaned', 'failed')"
+        },
+        "data_dump_runs_manifest_bytes_nonnegative": {
+          "name": "data_dump_runs_manifest_bytes_nonnegative",
+          "value": "\"data_dump_runs\".\"manifest_bytes\" is null or \"data_dump_runs\".\"manifest_bytes\" >= 0"
+        },
+        "data_dump_runs_manifest_sha256_length": {
+          "name": "data_dump_runs_manifest_sha256_length",
+          "value": "\"data_dump_runs\".\"manifest_sha256\" is null or octet_length(\"data_dump_runs\".\"manifest_sha256\") = 32"
+        },
+        "data_dump_runs_cleanup_eligible_at_offset": {
+          "name": "data_dump_runs_cleanup_eligible_at_offset",
+          "value": "\"data_dump_runs\".\"cleanup_eligible_at\" is null or \"data_dump_runs\".\"published_at\" is null or \"data_dump_runs\".\"cleanup_eligible_at\" = \"data_dump_runs\".\"published_at\" + interval '168 hours'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drop_ship_records": {
+      "name": "drop_ship_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "drop_ship_records_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "ship_id": {
+          "name": "ship_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quest": {
+          "name": "quest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cell_id": {
+          "name": "cell_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enemy": {
+          "name": "enemy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_boss": {
+          "name": "is_boss",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teitoku_lv": {
+          "name": "teitoku_lv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_lv": {
+          "name": "map_lv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enemy_ships1": {
+          "name": "enemy_ships1",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "enemy_ships2": {
+          "name": "enemy_ships2",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "enemy_formation": {
+          "name": "enemy_formation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_exp": {
+          "name": "base_exp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teitoku_id": {
+          "name": "teitoku_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_ship_snapshot": {
+          "name": "owned_ship_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "drop_ship_records_ingested_at_id_pk": {
+          "name": "drop_ship_records_ingested_at_id_pk",
+          "columns": ["ingested_at", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enemy_infos": {
+      "name": "enemy_infos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "enemy_infos_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "identity_hash": {
+          "name": "identity_hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ships1": {
+          "name": "ships1",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "levels1": {
+          "name": "levels1",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hp1": {
+          "name": "hp1",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ships2": {
+          "name": "ships2",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "levels2": {
+          "name": "levels2",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hp2": {
+          "name": "hp2",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stats1": {
+          "name": "stats1",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "equips1": {
+          "name": "equips1",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stats2": {
+          "name": "stats2",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "equips2": {
+          "name": "equips2",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planes": {
+          "name": "planes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bombers_min": {
+          "name": "bombers_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bombers_max": {
+          "name": "bombers_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count": {
+          "name": "count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "enemy_infos_identity_hash_unique": {
+          "name": "enemy_infos_identity_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["identity_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "enemy_infos_identity_hash_length": {
+          "name": "enemy_infos_identity_hash_length",
+          "value": "octet_length(\"enemy_infos\".\"identity_hash\") = 32"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.item_improvement_availability_facts": {
+      "name": "item_improvement_availability_facts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval('item_improvement_fact_id_seq')"
+        },
+        "export_id": {
+          "name": "export_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "lpad(to_hex(id), 24, '0')",
+            "type": "stored"
+          }
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_client_observed_at": {
+          "name": "first_client_observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_client_observed_at": {
+          "name": "last_client_observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_second_ship_id": {
+          "name": "observed_second_ship_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_flagship_ids": {
+          "name": "observed_flagship_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "sources": {
+          "name": "sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "origins": {
+          "name": "origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "first_reported": {
+          "name": "first_reported",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_reported": {
+          "name": "last_reported",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "item_improvement_availability_facts_last_reported_export_id_idx": {
+          "name": "item_improvement_availability_facts_last_reported_export_id_idx",
+          "columns": [
+            {
+              "expression": "last_reported",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "export_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_improvement_availability_facts_lookup_idx": {
+          "name": "item_improvement_availability_facts_lookup_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_second_ship_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_improvement_availability_facts_recipe_id_idx": {
+          "name": "item_improvement_availability_facts_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item_improvement_availability_facts_export_id_unique": {
+          "name": "item_improvement_availability_facts_export_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["export_id"]
+        },
+        "item_improvement_availability_facts_key_unique": {
+          "name": "item_improvement_availability_facts_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "item_improvement_availability_facts_export_id_format": {
+          "name": "item_improvement_availability_facts_export_id_format",
+          "value": "\"item_improvement_availability_facts\".\"export_id\" ~ '^[0-9a-f]{24}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.item_improvement_cost_facts": {
+      "name": "item_improvement_cost_facts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval('item_improvement_fact_id_seq')"
+        },
+        "export_id": {
+          "name": "export_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "lpad(to_hex(id), 24, '0')",
+            "type": "stored"
+          }
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_client_observed_at": {
+          "name": "first_client_observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_client_observed_at": {
+          "name": "last_client_observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_second_ship_id": {
+          "name": "observed_second_ship_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_flagship_ids": {
+          "name": "observed_flagship_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "sources": {
+          "name": "sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "origins": {
+          "name": "origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "first_reported": {
+          "name": "first_reported",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_reported": {
+          "name": "last_reported",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel": {
+          "name": "fuel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ammo": {
+          "name": "ammo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steel": {
+          "name": "steel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bauxite": {
+          "name": "bauxite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buildkit": {
+          "name": "buildkit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remodelkit": {
+          "name": "remodelkit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certain_buildkit": {
+          "name": "certain_buildkit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certain_remodelkit": {
+          "name": "certain_remodelkit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "req_slot_items": {
+          "name": "req_slot_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "req_use_items": {
+          "name": "req_use_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_flag": {
+          "name": "change_flag",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "item_improvement_cost_facts_last_reported_export_id_idx": {
+          "name": "item_improvement_cost_facts_last_reported_export_id_idx",
+          "columns": [
+            {
+              "expression": "last_reported",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "export_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_improvement_cost_facts_lookup_idx": {
+          "name": "item_improvement_cost_facts_lookup_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_second_ship_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_improvement_cost_facts_recipe_id_idx": {
+          "name": "item_improvement_cost_facts_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item_improvement_cost_facts_export_id_unique": {
+          "name": "item_improvement_cost_facts_export_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["export_id"]
+        },
+        "item_improvement_cost_facts_key_unique": {
+          "name": "item_improvement_cost_facts_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "item_improvement_cost_facts_export_id_format": {
+          "name": "item_improvement_cost_facts_export_id_format",
+          "value": "\"item_improvement_cost_facts\".\"export_id\" ~ '^[0-9a-f]{24}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.item_improvement_update_facts": {
+      "name": "item_improvement_update_facts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval('item_improvement_fact_id_seq')"
+        },
+        "export_id": {
+          "name": "export_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "lpad(to_hex(id), 24, '0')",
+            "type": "stored"
+          }
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_client_observed_at": {
+          "name": "first_client_observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_client_observed_at": {
+          "name": "last_client_observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_second_ship_id": {
+          "name": "observed_second_ship_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_flagship_ids": {
+          "name": "observed_flagship_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "sources": {
+          "name": "sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "origins": {
+          "name": "origins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "first_reported": {
+          "name": "first_reported",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_reported": {
+          "name": "last_reported",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upgrade_to_item_id": {
+          "name": "upgrade_to_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upgrade_to_item_level": {
+          "name": "upgrade_to_item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upgrade_observed": {
+          "name": "upgrade_observed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "item_improvement_update_facts_last_reported_export_id_idx": {
+          "name": "item_improvement_update_facts_last_reported_export_id_idx",
+          "columns": [
+            {
+              "expression": "last_reported",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "export_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_improvement_update_facts_lookup_idx": {
+          "name": "item_improvement_update_facts_lookup_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_second_ship_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_improvement_update_facts_recipe_id_idx": {
+          "name": "item_improvement_update_facts_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "item_improvement_update_facts_upgrade_to_item_id_idx": {
+          "name": "item_improvement_update_facts_upgrade_to_item_id_idx",
+          "columns": [
+            {
+              "expression": "upgrade_to_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "item_improvement_update_facts_export_id_unique": {
+          "name": "item_improvement_update_facts_export_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["export_id"]
+        },
+        "item_improvement_update_facts_key_unique": {
+          "name": "item_improvement_update_facts_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "item_improvement_update_facts_export_id_format": {
+          "name": "item_improvement_update_facts_export_id_format",
+          "value": "\"item_improvement_update_facts\".\"export_id\" ~ '^[0-9a-f]{24}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.night_battle_cis": {
+      "name": "night_battle_cis",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "night_battle_cis_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "ship_id": {
+          "name": "ship_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ci": {
+          "name": "ci",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lv": {
+          "name": "lv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_luck": {
+          "name": "raw_luck",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pos": {
+          "name": "pos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "items": {
+          "name": "items",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "improvement": {
+          "name": "improvement",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "search_light": {
+          "name": "search_light",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flare": {
+          "name": "flare",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "defense_id": {
+          "name": "defense_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "defense_type_id": {
+          "name": "defense_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ci_type": {
+          "name": "ci_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display": {
+          "name": "display",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "hit_type": {
+          "name": "hit_type",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "damage": {
+          "name": "damage",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "damage_total": {
+          "name": "damage_total",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "night_battle_cis_ingested_at_id_pk": {
+          "name": "night_battle_cis_ingested_at_id_pk",
+          "columns": ["ingested_at", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.night_contacts": {
+      "name": "night_contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "night_contacts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "fleet_type": {
+          "name": "fleet_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ship_id": {
+          "name": "ship_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ship_lv": {
+          "name": "ship_lv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_lv": {
+          "name": "item_lv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact": {
+          "name": "contact",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "night_contacts_ingested_at_id_pk": {
+          "name": "night_contacts_ingested_at_id_pk",
+          "columns": ["ingested_at", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pass_event_records": {
+      "name": "pass_event_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "pass_event_records_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "teitoku_id": {
+          "name": "teitoku_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teitoku_lv": {
+          "name": "teitoku_lv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_id": {
+          "name": "map_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map_lv": {
+          "name": "map_lv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewards": {
+          "name": "rewards",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pass_event_records_ingested_at_id_pk": {
+          "name": "pass_event_records_ingested_at_id_pk",
+          "columns": ["ingested_at", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quest_rewards": {
+      "name": "quest_rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "quest_rewards_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selections": {
+          "name": "selections",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "material": {
+          "name": "material",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "bonus": {
+          "name": "bonus",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "bonus_count": {
+          "name": "bonus_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "quest_rewards_key_quest_id_selections_bonus_count_key": {
+          "name": "quest_rewards_key_quest_id_selections_bonus_count_key",
+          "nullsNotDistinct": false,
+          "columns": ["key", "quest_id", "selections", "bonus_count"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "quest_rewards_key_format": {
+          "name": "quest_rewards_key_format",
+          "value": "\"quest_rewards\".\"key\" ~ '^[0-9a-f]{32}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quests": {
+      "name": "quests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "quests_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "quests_key_quest_id_category_key": {
+          "name": "quests_key_quest_id_category_key",
+          "nullsNotDistinct": false,
+          "columns": ["key", "quest_id", "category"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "quests_key_format": {
+          "name": "quests_key_format",
+          "value": "\"quests\".\"key\" ~ '^[0-9a-f]{32}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recipe_records": {
+      "name": "recipe_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "recipe_records_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secretary": {
+          "name": "secretary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fuel": {
+          "name": "fuel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ammo": {
+          "name": "ammo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steel": {
+          "name": "steel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bauxite": {
+          "name": "bauxite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "req_item_id": {
+          "name": "req_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "req_item_count": {
+          "name": "req_item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buildkit": {
+          "name": "buildkit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remodelkit": {
+          "name": "remodelkit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certain_buildkit": {
+          "name": "certain_buildkit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certain_remodelkit": {
+          "name": "certain_remodelkit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upgrade_to_item_id": {
+          "name": "upgrade_to_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upgrade_to_item_level": {
+          "name": "upgrade_to_item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reported": {
+          "name": "last_reported",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipe_records_identity_key": {
+          "name": "recipe_records_identity_key",
+          "nullsNotDistinct": false,
+          "columns": ["recipe_id", "item_id", "stage", "day", "secretary"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.remodel_item_records": {
+      "name": "remodel_item_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "remodel_item_records_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "clock_timestamp()"
+        },
+        "successful": {
+          "name": "successful",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flagship_id": {
+          "name": "flagship_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flagship_level": {
+          "name": "flagship_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flagship_cond": {
+          "name": "flagship_cond",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consort_id": {
+          "name": "consort_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consort_level": {
+          "name": "consort_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consort_cond": {
+          "name": "consort_cond",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teitoku_lv": {
+          "name": "teitoku_lv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certain": {
+          "name": "certain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "remodel_item_records_ingested_at_id_pk": {
+          "name": "remodel_item_records_ingested_at_id_pk",
+          "columns": ["ingested_at", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schema_metadata": {
+      "name": "schema_metadata",
+      "schema": "",
+      "columns": {
+        "singleton": {
+          "name": "singleton",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "schema_metadata_singleton_true": {
+          "name": "schema_metadata_singleton_true",
+          "value": "\"schema_metadata\".\"singleton\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.select_rank_records": {
+      "name": "select_rank_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "select_rank_records_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "teitoku_id": {
+          "name": "teitoku_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "maparea_id": {
+          "name": "maparea_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teitoku_lv": {
+          "name": "teitoku_lv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "select_rank_records_teitoku_maparea_key": {
+          "name": "select_rank_records_teitoku_maparea_key",
+          "nullsNotDistinct": false,
+          "columns": ["teitoku_id", "maparea_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ship_stats": {
+      "name": "ship_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "ship_stats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ship_id": {
+          "name": "ship_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lv": {
+          "name": "lv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "los": {
+          "name": "los",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "los_max": {
+          "name": "los_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asw": {
+          "name": "asw",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asw_max": {
+          "name": "asw_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evasion": {
+          "name": "evasion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evasion_max": {
+          "name": "evasion_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_timestamp": {
+          "name": "last_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ship_stats_identity_key": {
+          "name": "ship_stats_identity_key",
+          "nullsNotDistinct": false,
+          "columns": ["ship_id", "lv", "los", "los_max", "asw", "asw_max", "evasion", "evasion_max"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {
+    "public.item_improvement_fact_id_seq": {
+      "name": "item_improvement_fact_id_seq",
+      "schema": "public",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783790691472,
       "tag": "0001_remove_data_epochs",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1783800457588,
+      "tag": "0002_canonical_dump_month",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "db:dumps:publish": "tsx scripts/postgres-dump-publish.ts",
     "db:dumps:cleanup": "tsx scripts/postgres-dump-cleanup.ts",
     "db:dumps:maintain": "tsx scripts/postgres-dump-maintain.ts",
+    "db:dumps:r2-check": "tsx scripts/r2-connection-check.ts",
     "build": "npm run type-check && node --check scripts/smoke-server.cjs",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:partitions:repair": "tsx scripts/postgres-repair-monthly-partition.ts",
     "db:dumps:publish": "tsx scripts/postgres-dump-publish.ts",
     "db:dumps:cleanup": "tsx scripts/postgres-dump-cleanup.ts",
+    "db:dumps:maintain": "tsx scripts/postgres-dump-maintain.ts",
     "build": "npm run type-check && node --check scripts/smoke-server.cjs",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",

--- a/run-monthly-dump-maintenance
+++ b/run-monthly-dump-maintenance
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+APP_DIR="${POI_DUMP_CRON_APP_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+LOCK_FILE="${POI_DUMP_CRON_LOCK_FILE:-/var/lock/poi-server-monthly-dump.lock}"
+TIMEOUT="${POI_DUMP_CRON_TIMEOUT:-12h}"
+started_epoch="$(date +%s)"
+
+log_maintenance() {
+  printf '[poi-dump-maintenance] timestamp=%s %s\n' "$(date --iso-8601=seconds)" "$*"
+}
+
+on_error() {
+  local exit_code="$?"
+  local elapsed_seconds=$(( $(date +%s) - started_epoch ))
+  log_maintenance "status=failed exit_code=$exit_code elapsed_seconds=$elapsed_seconds"
+  exit "$exit_code"
+}
+
+trap on_error ERR
+
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  log_maintenance "status=skipped reason=overlap"
+  exit 0
+fi
+
+log_maintenance "status=started"
+cd "$APP_DIR"
+timeout --foreground "$TIMEOUT" ./fnm-exec npm run --silent db:dumps:maintain
+elapsed_seconds=$(( $(date +%s) - started_epoch ))
+log_maintenance "status=succeeded elapsed_seconds=$elapsed_seconds"

--- a/run-monthly-dump-maintenance.sh
+++ b/run-monthly-dump-maintenance.sh
@@ -33,10 +33,11 @@ on_error() {
 
 trap on_error ERR
 
-safe_path_pattern='^[/._A-Za-z0-9][A-Za-z0-9_./-]*$'
-[[ "$APP_DIR" =~ $safe_path_pattern ]] || fail "POI_DUMP_CRON_APP_DIR contains unsupported characters"
-[[ "$LOCK_FILE" =~ $safe_path_pattern ]] ||
-  fail "POI_DUMP_CRON_LOCK_FILE contains unsupported characters"
+absolute_path_pattern='^/[A-Za-z0-9_./-]*$'
+[[ "$APP_DIR" =~ $absolute_path_pattern ]] ||
+  fail "POI_DUMP_CRON_APP_DIR must be an absolute path with supported characters"
+[[ "$LOCK_FILE" =~ $absolute_path_pattern ]] ||
+  fail "POI_DUMP_CRON_LOCK_FILE must be an absolute path with supported characters"
 [[ "$TIMEOUT" =~ ^[1-9][0-9]*[smhd]$ ]] ||
   fail "POI_DUMP_CRON_TIMEOUT must be a positive duration ending in s, m, h, or d"
 [[ -x "$APP_DIR/fnm-exec" ]] || fail "$APP_DIR/fnm-exec is not executable"

--- a/run-monthly-dump-maintenance.sh
+++ b/run-monthly-dump-maintenance.sh
@@ -6,6 +6,11 @@ LOCK_FILE="${POI_DUMP_CRON_LOCK_FILE:-/var/lock/poi-server-monthly-dump.lock}"
 TIMEOUT="${POI_DUMP_CRON_TIMEOUT:-12h}"
 started_epoch="$(date +%s)"
 
+fail() {
+  printf '[poi-dump-maintenance] error: %s\n' "$*" >&2
+  exit 1
+}
+
 log_maintenance() {
   printf '[poi-dump-maintenance] timestamp=%s %s\n' "$(date --iso-8601=seconds)" "$*"
 }
@@ -19,6 +24,13 @@ on_error() {
 
 trap on_error ERR
 
+safe_path_pattern='^[/._A-Za-z0-9][A-Za-z0-9_./-]*$'
+[[ "$APP_DIR" =~ $safe_path_pattern ]] || fail "POI_DUMP_CRON_APP_DIR contains unsupported characters"
+[[ "$LOCK_FILE" =~ $safe_path_pattern ]] ||
+  fail "POI_DUMP_CRON_LOCK_FILE contains unsupported characters"
+[[ "$TIMEOUT" =~ ^[1-9][0-9]*[smhd]$ ]] ||
+  fail "POI_DUMP_CRON_TIMEOUT must be a positive duration ending in s, m, h, or d"
+
 exec 9>"$LOCK_FILE"
 if ! flock -n 9; then
   log_maintenance "status=skipped reason=overlap"
@@ -26,7 +38,7 @@ if ! flock -n 9; then
 fi
 
 log_maintenance "status=started"
-cd "$APP_DIR"
-timeout --foreground "$TIMEOUT" ./fnm-exec npm run --silent db:dumps:maintain
+cd -- "$APP_DIR"
+timeout --foreground -- "$TIMEOUT" ./fnm-exec npm run --silent db:dumps:maintain
 elapsed_seconds=$(( $(date +%s) - started_epoch ))
 log_maintenance "status=succeeded elapsed_seconds=$elapsed_seconds"

--- a/run-monthly-dump-maintenance.sh
+++ b/run-monthly-dump-maintenance.sh
@@ -30,6 +30,7 @@ safe_path_pattern='^[/._A-Za-z0-9][A-Za-z0-9_./-]*$'
   fail "POI_DUMP_CRON_LOCK_FILE contains unsupported characters"
 [[ "$TIMEOUT" =~ ^[1-9][0-9]*[smhd]$ ]] ||
   fail "POI_DUMP_CRON_TIMEOUT must be a positive duration ending in s, m, h, or d"
+[[ -x "$APP_DIR/fnm-exec" ]] || fail "$APP_DIR/fnm-exec is not executable"
 
 exec 9>"$LOCK_FILE"
 if ! flock -n 9; then

--- a/run-monthly-dump-maintenance.sh
+++ b/run-monthly-dump-maintenance.sh
@@ -4,12 +4,21 @@ set -Eeuo pipefail
 APP_DIR="${POI_DUMP_CRON_APP_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 LOCK_FILE="${POI_DUMP_CRON_LOCK_FILE:-/var/lock/poi-server-monthly-dump.lock}"
 TIMEOUT="${POI_DUMP_CRON_TIMEOUT:-12h}"
-started_epoch="$(date +%s)"
 
 fail() {
   printf '[poi-dump-maintenance] error: %s\n' "$*" >&2
   exit 1
 }
+
+command -v date >/dev/null || fail "date is required"
+command -v flock >/dev/null || fail "flock is required"
+command -v timeout >/dev/null || fail "timeout is required"
+date --iso-8601=seconds >/dev/null 2>&1 || fail "GNU date with --iso-8601=seconds is required"
+flock --version >/dev/null 2>&1 || fail "util-linux flock is required"
+timeout --foreground -- 1s true >/dev/null 2>&1 ||
+  fail "GNU timeout with --foreground is required"
+
+started_epoch="$(date +%s)"
 
 log_maintenance() {
   printf '[poi-dump-maintenance] timestamp=%s %s\n' "$(date --iso-8601=seconds)" "$*"

--- a/scripts/postgres-dump-maintain.ts
+++ b/scripts/postgres-dump-maintain.ts
@@ -1,0 +1,10 @@
+import 'dotenv/config'
+
+import { runDumpMaintenanceCommand } from '../src/cli/postgres-dump-maintenance-command'
+
+void runDumpMaintenanceCommand(process.argv.slice(2), process.env)
+  .then((result) => console.log(JSON.stringify(result, null, 2)))
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })

--- a/scripts/r2-connection-check.ts
+++ b/scripts/r2-connection-check.ts
@@ -1,0 +1,10 @@
+import 'dotenv/config'
+
+import { runR2ConnectionCheckCommand } from '../src/cli/r2-connection-check-command'
+
+void runR2ConnectionCheckCommand(process.argv.slice(2), process.env)
+  .then((result) => console.log(JSON.stringify(result, null, 2)))
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })

--- a/setup-monthly-dump-cron
+++ b/setup-monthly-dump-cron
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+APP_DIR="${POI_DUMP_CRON_APP_DIR:-/srv/poi}"
+CRON_USER="${POI_DUMP_CRON_USER:-poi}"
+CRON_SCHEDULE="${POI_DUMP_CRON_SCHEDULE:-30 0 * * *}"
+LOG_FILE="${POI_DUMP_CRON_LOG_FILE:-/var/log/poi-server/monthly-dump.log}"
+LOCK_FILE="${POI_DUMP_CRON_LOCK_FILE:-/var/lock/poi-server-monthly-dump.lock}"
+TIMEOUT="${POI_DUMP_CRON_TIMEOUT:-12h}"
+BEGIN_MARKER="# BEGIN poi-server monthly dump"
+END_MARKER="# END poi-server monthly dump"
+
+fail() {
+  printf '[poi-dump-cron] error: %s\n' "$*" >&2
+  exit 1
+}
+
+safe_path_pattern='^[A-Za-z0-9_./-]+$'
+[[ "$APP_DIR" =~ $safe_path_pattern ]] || fail "POI_DUMP_CRON_APP_DIR contains unsupported characters"
+[[ "$LOG_FILE" =~ $safe_path_pattern ]] || fail "POI_DUMP_CRON_LOG_FILE contains unsupported characters"
+[[ "$LOCK_FILE" =~ $safe_path_pattern ]] || fail "POI_DUMP_CRON_LOCK_FILE contains unsupported characters"
+[[ "$CRON_USER" =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]] || fail "POI_DUMP_CRON_USER is invalid"
+[[ "$TIMEOUT" =~ ^[1-9][0-9]*[smhd]$ ]] ||
+  fail "POI_DUMP_CRON_TIMEOUT must be a positive duration ending in s, m, h, or d"
+[[ "$CRON_SCHEDULE" =~ ^[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]+[^[:space:]]+$ ]] ||
+  fail "POI_DUMP_CRON_SCHEDULE must contain exactly five cron fields"
+[[ -x "$APP_DIR/run-monthly-dump-maintenance" ]] ||
+  fail "$APP_DIR/run-monthly-dump-maintenance is not executable"
+command -v crontab >/dev/null || fail "crontab is required"
+command -v flock >/dev/null || fail "flock is required"
+command -v timeout >/dev/null || fail "timeout is required"
+id "$CRON_USER" >/dev/null 2>&1 || fail "user $CRON_USER does not exist"
+
+cron_group="$(id -gn "$CRON_USER")"
+install -d -o "$CRON_USER" -g "$cron_group" -m 0750 "$(dirname "$LOG_FILE")"
+if [ ! -d "$(dirname "$LOCK_FILE")" ]; then
+  install -d -o "$CRON_USER" -g "$cron_group" -m 0750 "$(dirname "$LOCK_FILE")"
+fi
+touch "$LOG_FILE" "$LOCK_FILE"
+chown "$CRON_USER:$cron_group" "$LOG_FILE" "$LOCK_FILE"
+chmod 0640 "$LOG_FILE"
+chmod 0600 "$LOCK_FILE"
+
+current_crontab="$(mktemp)"
+filtered_crontab="$(mktemp)"
+new_crontab="$(mktemp)"
+trap 'rm -f "$current_crontab" "$filtered_crontab" "$new_crontab"' EXIT
+
+crontab -u "$CRON_USER" -l >"$current_crontab" 2>/dev/null || true
+if ! awk -v begin="$BEGIN_MARKER" -v end="$END_MARKER" '
+  $0 == begin {
+    if (managed || seen) exit 42
+    managed = 1
+    seen = 1
+    next
+  }
+  $0 == end {
+    if (!managed) exit 42
+    managed = 0
+    next
+  }
+  !managed { print }
+  END {
+    if (managed) exit 42
+  }
+' "$current_crontab" >"$filtered_crontab"; then
+  fail "existing monthly dump crontab markers are malformed"
+fi
+
+{
+  cat "$filtered_crontab"
+  if [ -s "$filtered_crontab" ]; then
+    printf '\n'
+  fi
+  printf '%s\n' "$BEGIN_MARKER"
+  printf '%s\n' '# Runs at 00:30 JST by default; the maintenance command is idempotent and retry-safe.'
+  printf '%s\n' 'CRON_TZ=Asia/Tokyo'
+  printf '%s cd %s && POI_DUMP_CRON_LOCK_FILE=%s POI_DUMP_CRON_TIMEOUT=%s ./run-monthly-dump-maintenance >> %s 2>&1\n' \
+    "$CRON_SCHEDULE" "$APP_DIR" "$LOCK_FILE" "$TIMEOUT" "$LOG_FILE"
+  printf '%s\n' "$END_MARKER"
+} >"$new_crontab"
+
+crontab -u "$CRON_USER" "$new_crontab"
+printf '[poi-dump-cron] installed user=%s schedule="%s" log=%s\n' \
+  "$CRON_USER" "$CRON_SCHEDULE" "$LOG_FILE"

--- a/setup-monthly-dump-cron.sh
+++ b/setup-monthly-dump-cron.sh
@@ -26,6 +26,7 @@ safe_path_pattern='^[/._A-Za-z0-9][A-Za-z0-9_./-]*$'
   fail "POI_DUMP_CRON_SCHEDULE must contain exactly five cron fields"
 [[ -x "$APP_DIR/run-monthly-dump-maintenance.sh" ]] ||
   fail "$APP_DIR/run-monthly-dump-maintenance.sh is not executable"
+[[ -x "$APP_DIR/fnm-exec" ]] || fail "$APP_DIR/fnm-exec is not executable"
 command -v crontab >/dev/null || fail "crontab is required"
 command -v flock >/dev/null || fail "flock is required"
 command -v timeout >/dev/null || fail "timeout is required"

--- a/setup-monthly-dump-cron.sh
+++ b/setup-monthly-dump-cron.sh
@@ -28,8 +28,13 @@ safe_path_pattern='^[/._A-Za-z0-9][A-Za-z0-9_./-]*$'
   fail "$APP_DIR/run-monthly-dump-maintenance.sh is not executable"
 [[ -x "$APP_DIR/fnm-exec" ]] || fail "$APP_DIR/fnm-exec is not executable"
 command -v crontab >/dev/null || fail "crontab is required"
+command -v date >/dev/null || fail "date is required"
 command -v flock >/dev/null || fail "flock is required"
 command -v timeout >/dev/null || fail "timeout is required"
+date --iso-8601=seconds >/dev/null 2>&1 || fail "GNU date with --iso-8601=seconds is required"
+flock --version >/dev/null 2>&1 || fail "util-linux flock is required"
+timeout --foreground -- 1s true >/dev/null 2>&1 ||
+  fail "GNU timeout with --foreground is required"
 id "$CRON_USER" >/dev/null 2>&1 || fail "user $CRON_USER does not exist"
 
 cron_group="$(id -gn "$CRON_USER")"

--- a/setup-monthly-dump-cron.sh
+++ b/setup-monthly-dump-cron.sh
@@ -15,7 +15,7 @@ fail() {
   exit 1
 }
 
-safe_path_pattern='^[A-Za-z0-9_./-]+$'
+safe_path_pattern='^[/._A-Za-z0-9][A-Za-z0-9_./-]*$'
 [[ "$APP_DIR" =~ $safe_path_pattern ]] || fail "POI_DUMP_CRON_APP_DIR contains unsupported characters"
 [[ "$LOG_FILE" =~ $safe_path_pattern ]] || fail "POI_DUMP_CRON_LOG_FILE contains unsupported characters"
 [[ "$LOCK_FILE" =~ $safe_path_pattern ]] || fail "POI_DUMP_CRON_LOCK_FILE contains unsupported characters"
@@ -24,8 +24,8 @@ safe_path_pattern='^[A-Za-z0-9_./-]+$'
   fail "POI_DUMP_CRON_TIMEOUT must be a positive duration ending in s, m, h, or d"
 [[ "$CRON_SCHEDULE" =~ ^[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]+[^[:space:]]+$ ]] ||
   fail "POI_DUMP_CRON_SCHEDULE must contain exactly five cron fields"
-[[ -x "$APP_DIR/run-monthly-dump-maintenance" ]] ||
-  fail "$APP_DIR/run-monthly-dump-maintenance is not executable"
+[[ -x "$APP_DIR/run-monthly-dump-maintenance.sh" ]] ||
+  fail "$APP_DIR/run-monthly-dump-maintenance.sh is not executable"
 command -v crontab >/dev/null || fail "crontab is required"
 command -v flock >/dev/null || fail "flock is required"
 command -v timeout >/dev/null || fail "timeout is required"
@@ -75,7 +75,7 @@ fi
   printf '%s\n' "$BEGIN_MARKER"
   printf '%s\n' '# Runs at 00:30 JST by default; the maintenance command is idempotent and retry-safe.'
   printf '%s\n' 'CRON_TZ=Asia/Tokyo'
-  printf '%s cd %s && POI_DUMP_CRON_LOCK_FILE=%s POI_DUMP_CRON_TIMEOUT=%s ./run-monthly-dump-maintenance >> %s 2>&1\n' \
+  printf '%s cd %s && POI_DUMP_CRON_LOCK_FILE=%s POI_DUMP_CRON_TIMEOUT=%s ./run-monthly-dump-maintenance.sh >> %s 2>&1\n' \
     "$CRON_SCHEDULE" "$APP_DIR" "$LOCK_FILE" "$TIMEOUT" "$LOG_FILE"
   printf '%s\n' "$END_MARKER"
 } >"$new_crontab"

--- a/setup-monthly-dump-cron.sh
+++ b/setup-monthly-dump-cron.sh
@@ -15,10 +15,13 @@ fail() {
   exit 1
 }
 
-safe_path_pattern='^[/._A-Za-z0-9][A-Za-z0-9_./-]*$'
-[[ "$APP_DIR" =~ $safe_path_pattern ]] || fail "POI_DUMP_CRON_APP_DIR contains unsupported characters"
-[[ "$LOG_FILE" =~ $safe_path_pattern ]] || fail "POI_DUMP_CRON_LOG_FILE contains unsupported characters"
-[[ "$LOCK_FILE" =~ $safe_path_pattern ]] || fail "POI_DUMP_CRON_LOCK_FILE contains unsupported characters"
+absolute_path_pattern='^/[A-Za-z0-9_./-]*$'
+[[ "$APP_DIR" =~ $absolute_path_pattern ]] ||
+  fail "POI_DUMP_CRON_APP_DIR must be an absolute path with supported characters"
+[[ "$LOG_FILE" =~ $absolute_path_pattern ]] ||
+  fail "POI_DUMP_CRON_LOG_FILE must be an absolute path with supported characters"
+[[ "$LOCK_FILE" =~ $absolute_path_pattern ]] ||
+  fail "POI_DUMP_CRON_LOCK_FILE must be an absolute path with supported characters"
 [[ "$CRON_USER" =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]] || fail "POI_DUMP_CRON_USER is invalid"
 [[ "$TIMEOUT" =~ ^[1-9][0-9]*[smhd]$ ]] ||
   fail "POI_DUMP_CRON_TIMEOUT must be a positive duration ending in s, m, h, or d"

--- a/src/cli/dump-command-support.ts
+++ b/src/cli/dump-command-support.ts
@@ -12,22 +12,14 @@ import {
 } from '../object-store/r2-object-store'
 
 /**
- * Shared plumbing for the Community Dump publish/cleanup CLI commands
- * (docs/postgresql-migration-plan.md lines 622-811): both `runPublishDumpMonthCommand`
- * (postgres-dump-publish-command.ts) and `runCleanupDumpRunCommand`
- * (postgres-dump-cleanup-command.ts) validate their one CLI argument first, then require a
- * PostgreSQL backend, then load `POI_SERVER_DUMP_R2_*` config, then wire an offline pg `Pool`
- * through the `DumpPool` adapter — in that exact order, so a malformed argument or a non-Postgres
- * backend never causes a database connection or an R2 client to be created. This module holds
- * every piece of that sequencing that both commands share; each command module adds only its own
- * workflow function (`publishDumpMonth`/`cleanupDumpRun`) to `DumpCommandDeps`.
+ * Shared plumbing for the Community Dump publish, cleanup, and scheduled-maintenance CLI commands
+ * (docs/postgresql-migration-plan.md lines 622-811). They validate argv first, require a PostgreSQL
+ * backend, load `POI_SERVER_DUMP_R2_*` config, and wire an offline pg `Pool` through the `DumpPool`
+ * adapter in that order, so malformed arguments or a non-Postgres backend never create database or
+ * R2 clients. Each command module adds only its own workflow dependencies to `DumpCommandDeps`.
  *
- * Every dependency the two commands need is injectable via `DumpCommandDeps` specifically so
- * `runPublishDumpMonthCommand`/`runCleanupDumpRunCommand` are unit-testable end to end with plain
- * fakes (tests/postgres-dump-publish-command.test.ts, tests/postgres-dump-cleanup-command.test.ts)
- * — no test in this repository spawns either CLI script as a child process, and the scripts
- * themselves (scripts/postgres-dump-publish.ts, scripts/postgres-dump-cleanup.ts) stay thin argv/
- * env/exit-code wiring with no logic of their own.
+ * Every dependency is injectable via `DumpCommandDeps` so command sequencing remains unit-testable
+ * with plain fakes. The scripts themselves stay thin argv/env/exit-code wiring with no logic.
  */
 export type CliEnv = Partial<Record<string, string>>
 
@@ -59,6 +51,12 @@ export const requireExactlyOneArg = (args: readonly string[], usage: string): st
     throw new Error(`Usage: ${usage}`)
   }
   return only
+}
+
+export const requireNoArgs = (args: readonly string[], usage: string): void => {
+  if (args.length > 0) {
+    throw new Error(`Usage: ${usage}`)
+  }
 }
 
 const extractDatabaseUrlPassword = (databaseUrl: string): string | null => {

--- a/src/cli/postgres-dump-maintenance-command.ts
+++ b/src/cli/postgres-dump-maintenance-command.ts
@@ -1,0 +1,139 @@
+import { cleanupDumpRun, type CleanupDumpRunResult } from '../db/postgres/dumps/cleanup-dump-run'
+import {
+  listCleanupEligibleDumpRuns,
+  type DumpRunRow,
+} from '../db/postgres/dumps/dump-run-repository'
+import { publishDumpMonth } from '../db/postgres/dumps/publish-dump-month'
+import {
+  createUpcomingMonthPartitions,
+  type CreateUpcomingMonthPartitionOutcome,
+} from '../db/postgres/partitions/create-upcoming-month'
+import { deriveAdjacentJstDumpMonths } from '../db/postgres/partitions/dump-month'
+import {
+  collectDatabaseUrlSecret,
+  collectR2Secrets,
+  defaultDumpCommandDeps,
+  requireNoArgs,
+  requirePostgresBackend,
+  sanitizeCommandError,
+  type CliEnv,
+  type DumpCommandDeps,
+} from './dump-command-support'
+
+export interface DumpMaintenanceCommandDeps extends DumpCommandDeps {
+  readonly now: () => Date
+  readonly createUpcomingMonthPartitions: typeof createUpcomingMonthPartitions
+  readonly publishDumpMonth: typeof publishDumpMonth
+  readonly listCleanupEligibleDumpRuns: typeof listCleanupEligibleDumpRuns
+  readonly cleanupDumpRun: typeof cleanupDumpRun
+}
+
+export interface DumpMaintenanceResult {
+  readonly previousDumpMonth: string
+  readonly upcomingDumpMonth: string
+  readonly partitions: readonly CreateUpcomingMonthPartitionOutcome[]
+  readonly publishedRun: DumpRunRow
+  readonly cleanups: readonly CleanupDumpRunResult[]
+}
+
+export const defaultDumpMaintenanceCommandDeps: DumpMaintenanceCommandDeps = {
+  ...defaultDumpCommandDeps,
+  now: () => new Date(),
+  createUpcomingMonthPartitions,
+  publishDumpMonth,
+  listCleanupEligibleDumpRuns,
+  cleanupDumpRun,
+}
+
+export const dumpMaintenanceCommandUsage = 'db:dumps:maintain'
+
+export const runDumpMaintenanceCommand = async (
+  args: readonly string[],
+  env: CliEnv,
+  deps: DumpMaintenanceCommandDeps = defaultDumpMaintenanceCommandDeps,
+): Promise<DumpMaintenanceResult> => {
+  requireNoArgs(args, dumpMaintenanceCommandUsage)
+  const { previous, next } = deriveAdjacentJstDumpMonths(deps.now())
+
+  const secrets: string[] = []
+  try {
+    const databaseUrl = deps.resolveDatabaseUrl(env)
+    collectDatabaseUrlSecret(databaseUrl, secrets)
+    requirePostgresBackend(databaseUrl, deps, 'Community Dump maintenance')
+
+    const r2Config = deps.loadR2Config(env)
+    collectR2Secrets(r2Config, secrets)
+    const objectStore = deps.createObjectStore(r2Config)
+
+    const pool = deps.createOfflineDumpPool(databaseUrl)
+    try {
+      const dumpPool = deps.createDumpPoolFromPgPool(pool)
+
+      const failures: string[] = []
+      let partitions: readonly CreateUpcomingMonthPartitionOutcome[] | undefined
+      let publishedRun: DumpRunRow | undefined
+      const cleanups: CleanupDumpRunResult[] = []
+
+      try {
+        partitions = await deps.createUpcomingMonthPartitions(pool, next)
+      } catch (error) {
+        failures.push(
+          `create upcoming partitions for ${next}: ${error instanceof Error ? error.message : String(error)}`,
+        )
+      }
+
+      try {
+        publishedRun = await deps.publishDumpMonth(dumpPool, objectStore, previous)
+      } catch (error) {
+        failures.push(
+          `publish Dump Month ${previous}: ${error instanceof Error ? error.message : String(error)}`,
+        )
+      }
+
+      let eligibleRuns: readonly DumpRunRow[] = []
+      try {
+        const client = await dumpPool.connect()
+        try {
+          eligibleRuns = await deps.listCleanupEligibleDumpRuns(client)
+        } finally {
+          client.release()
+        }
+      } catch (error) {
+        failures.push(
+          `discover cleanup-eligible runs: ${error instanceof Error ? error.message : String(error)}`,
+        )
+      }
+
+      for (const run of eligibleRuns) {
+        try {
+          cleanups.push(await deps.cleanupDumpRun(dumpPool, objectStore, run.id))
+        } catch (error) {
+          failures.push(
+            `clean dump run ${run.id}: ${error instanceof Error ? error.message : String(error)}`,
+          )
+        }
+      }
+
+      if (failures.length > 0) {
+        throw new Error(
+          `Community Dump maintenance completed with ${failures.length} failure(s):\n${failures.join('\n')}`,
+        )
+      }
+      if (partitions === undefined || publishedRun === undefined) {
+        throw new Error('Community Dump maintenance completed without required phase results')
+      }
+
+      return {
+        previousDumpMonth: previous,
+        upcomingDumpMonth: next,
+        partitions,
+        publishedRun,
+        cleanups,
+      }
+    } finally {
+      await deps.endPool(pool)
+    }
+  } catch (error) {
+    throw sanitizeCommandError(error, secrets)
+  }
+}

--- a/src/cli/postgres-dump-maintenance-command.ts
+++ b/src/cli/postgres-dump-maintenance-command.ts
@@ -61,10 +61,6 @@ export const runDumpMaintenanceCommand = async (
     collectDatabaseUrlSecret(databaseUrl, secrets)
     requirePostgresBackend(databaseUrl, deps, 'Community Dump maintenance')
 
-    const r2Config = deps.loadR2Config(env)
-    collectR2Secrets(r2Config, secrets)
-    const objectStore = deps.createObjectStore(r2Config)
-
     const pool = deps.createOfflineDumpPool(databaseUrl)
     try {
       const dumpPool = deps.createDumpPoolFromPgPool(pool)
@@ -82,35 +78,48 @@ export const runDumpMaintenanceCommand = async (
         )
       }
 
+      let objectStore: ReturnType<DumpCommandDeps['createObjectStore']> | undefined
       try {
-        publishedRun = await deps.publishDumpMonth(dumpPool, objectStore, previous)
+        const r2Config = deps.loadR2Config(env)
+        collectR2Secrets(r2Config, secrets)
+        objectStore = deps.createObjectStore(r2Config)
       } catch (error) {
         failures.push(
-          `publish Dump Month ${previous}: ${error instanceof Error ? error.message : String(error)}`,
+          `initialize R2 object store: ${error instanceof Error ? error.message : String(error)}`,
         )
       }
 
-      let eligibleRuns: readonly DumpRunRow[] = []
-      try {
-        const client = await dumpPool.connect()
+      if (objectStore !== undefined) {
         try {
-          eligibleRuns = await deps.listCleanupEligibleDumpRuns(client)
-        } finally {
-          client.release()
-        }
-      } catch (error) {
-        failures.push(
-          `discover cleanup-eligible runs: ${error instanceof Error ? error.message : String(error)}`,
-        )
-      }
-
-      for (const run of eligibleRuns) {
-        try {
-          cleanups.push(await deps.cleanupDumpRun(dumpPool, objectStore, run.id))
+          publishedRun = await deps.publishDumpMonth(dumpPool, objectStore, previous)
         } catch (error) {
           failures.push(
-            `clean dump run ${run.id}: ${error instanceof Error ? error.message : String(error)}`,
+            `publish Dump Month ${previous}: ${error instanceof Error ? error.message : String(error)}`,
           )
+        }
+
+        let eligibleRuns: readonly DumpRunRow[] = []
+        try {
+          const client = await dumpPool.connect()
+          try {
+            eligibleRuns = await deps.listCleanupEligibleDumpRuns(client)
+          } finally {
+            client.release()
+          }
+        } catch (error) {
+          failures.push(
+            `discover cleanup-eligible runs: ${error instanceof Error ? error.message : String(error)}`,
+          )
+        }
+
+        for (const run of eligibleRuns) {
+          try {
+            cleanups.push(await deps.cleanupDumpRun(dumpPool, objectStore, run.id))
+          } catch (error) {
+            failures.push(
+              `clean dump run ${run.id}: ${error instanceof Error ? error.message : String(error)}`,
+            )
+          }
         }
       }
 

--- a/src/cli/r2-connection-check-command.ts
+++ b/src/cli/r2-connection-check-command.ts
@@ -1,0 +1,114 @@
+import { createHash, randomBytes, randomUUID } from 'crypto'
+
+import { createS3ObjectClient, type S3ConnectionCheckClient } from '../object-store/r2-client'
+import { loadR2ObjectStoreConfigFromEnv } from '../object-store/r2-object-store'
+import {
+  collectR2Secrets,
+  requireNoArgs,
+  sanitizeCommandError,
+  type CliEnv,
+} from './dump-command-support'
+
+export interface R2ConnectionCheckResult {
+  readonly action: 'verified-and-deleted'
+  readonly bucket: string
+  readonly key: string
+  readonly bytes: number
+  readonly sha256: string
+}
+
+export interface R2ConnectionCheckCommandDeps {
+  readonly loadR2Config: typeof loadR2ObjectStoreConfigFromEnv
+  readonly createS3Client: (
+    config: ReturnType<typeof loadR2ObjectStoreConfigFromEnv>,
+  ) => S3ConnectionCheckClient
+  readonly createProbeKey: () => string
+  readonly createProbeBody: () => Buffer
+}
+
+export const defaultR2ConnectionCheckCommandDeps: R2ConnectionCheckCommandDeps = {
+  loadR2Config: loadR2ObjectStoreConfigFromEnv,
+  createS3Client: createS3ObjectClient,
+  createProbeKey: () => `healthchecks/poi-server/r2-connection/${randomUUID()}`,
+  createProbeBody: () => randomBytes(32),
+}
+
+export const r2ConnectionCheckCommandUsage = 'db:dumps:r2-check'
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+export const runR2ConnectionCheckCommand = async (
+  args: readonly string[],
+  env: CliEnv,
+  deps: R2ConnectionCheckCommandDeps = defaultR2ConnectionCheckCommandDeps,
+): Promise<R2ConnectionCheckResult> => {
+  requireNoArgs(args, r2ConnectionCheckCommandUsage)
+
+  const secrets: string[] = []
+  try {
+    const config = deps.loadR2Config(env)
+    collectR2Secrets(config, secrets)
+    const client = deps.createS3Client(config)
+    const key = deps.createProbeKey()
+    const body = deps.createProbeBody()
+    const sha256 = createHash('sha256').update(body).digest('hex')
+
+    let uploaded = false
+    let verified = false
+    let operationError: unknown
+    try {
+      await client.putObject({
+        bucket: config.bucket,
+        key,
+        body,
+        ifNoneMatch: '*',
+      })
+      uploaded = true
+
+      const stored = await client.getObject({ bucket: config.bucket, key })
+      if (!stored.equals(body)) {
+        throw new Error(
+          `R2 connection check read-back mismatch for temporary object "${key}" in bucket "${config.bucket}"`,
+        )
+      }
+      verified = true
+    } catch (error) {
+      operationError = error
+    }
+
+    let cleanupError: unknown
+    if (uploaded) {
+      try {
+        await client.deleteObject({ bucket: config.bucket, key })
+      } catch (error) {
+        cleanupError = error
+      }
+    }
+
+    if (operationError !== undefined || cleanupError !== undefined) {
+      const failures: string[] = []
+      if (operationError !== undefined) {
+        failures.push(`temporary object "${key}" probe failed: ${errorMessage(operationError)}`)
+      }
+      if (cleanupError !== undefined) {
+        failures.push(`temporary object "${key}" cleanup failed: ${errorMessage(cleanupError)}`)
+      }
+      throw new Error(`R2 connection check failed:\n${failures.join('\n')}`)
+    }
+
+    if (!verified) {
+      throw new Error('R2 connection check completed without verifying the temporary object')
+    }
+
+    return {
+      action: 'verified-and-deleted',
+      bucket: config.bucket,
+      key,
+      bytes: body.length,
+      sha256,
+    }
+  } catch (error) {
+    throw sanitizeCommandError(error, secrets)
+  }
+}

--- a/src/db/postgres/dumps/dump-run-repository.ts
+++ b/src/db/postgres/dumps/dump-run-repository.ts
@@ -239,6 +239,26 @@ export const loadDumpRunById = async (
 }
 
 /**
+ * Lists only runs whose database-clock grace period has elapsed. The maintenance command still
+ * sends each exact id through cleanupDumpRun, which re-verifies eligibility and all destructive
+ * preconditions under its own locks before dropping anything.
+ */
+export const listCleanupEligibleDumpRuns = async (
+  client: PartitionQueryClient,
+): Promise<readonly DumpRunRow[]> => {
+  const result = await client.query(
+    `
+select ${dumpRunColumns}
+from data_dump_runs
+where status in ('published', 'cleanup_eligible')
+  and cleanup_eligible_at <= clock_timestamp()
+order by cleanup_eligible_at, id
+`.trim(),
+  )
+  return result.rows.map(mapDumpRunRow)
+}
+
+/**
  * Identical to {@link loadDumpRunById}, except it takes a `for update` row lock. Reserved for the
  * cleanup workflow's final destructive transaction (docs/postgresql-migration-plan.md lines
  * 759, 762-764), immediately before it re-proves the run's metadata/status has not changed since

--- a/src/db/postgres/dumps/dump-run-repository.ts
+++ b/src/db/postgres/dumps/dump-run-repository.ts
@@ -201,29 +201,50 @@ const dumpMonthDateLiteral = (parts: DumpMonthParts): string =>
   `${parts.year.toString().padStart(4, '0')}-${String(parts.month).padStart(2, '0')}-01`
 
 /**
- * Finds or creates the one `data_dump_runs` row for `(dumpMonth, schemaVersion)`
- * (plan lines 736-739, 761-762: "Persist/resume one unique data_dump_runs row"). A fresh row
- * starts at `status = 'pending'`; resuming an existing row leaves every already-persisted column
- * untouched (only `updated_at` moves), so a retry continues from wherever the previous attempt
- * left off instead of losing its progress.
+ * Finds or creates the one canonical `data_dump_runs` row for a Dump Month. A fresh row starts at
+ * `status = 'pending'`; resuming an existing row leaves every already-persisted column untouched
+ * (only `updated_at` moves), so a retry continues from wherever the previous attempt left off
+ * instead of losing its progress. A different schema version for an already-reserved month is
+ * rejected: object keys are immutable and intentionally identify one canonical publication per
+ * Dump Month, while the manifest records which schema that publication uses.
  */
 export const findOrCreateDumpRun = async (
   client: PartitionQueryClient,
   input: FindOrCreateDumpRunInput,
 ): Promise<DumpRunRow> => {
+  const dumpMonthLiteral = dumpMonthDateLiteral(input.dumpMonth)
   const result = await client.query(
     `
 insert into data_dump_runs (dump_month, schema_version, status)
 values ($1, $2, 'pending')
-on conflict (dump_month, schema_version)
+on conflict (dump_month)
 do update set updated_at = clock_timestamp()
+where data_dump_runs.schema_version = excluded.schema_version
 returning ${dumpRunColumns}
 `.trim(),
-    [dumpMonthDateLiteral(input.dumpMonth), input.schemaVersion],
+    [dumpMonthLiteral, input.schemaVersion],
   )
-  return mapDumpRunRow(
-    singleRowOrThrow(result.rows, 'findOrCreateDumpRun: insert...on conflict returned no row'),
-  )
+
+  const [runRow] = result.rows
+  if (!runRow) {
+    const existingResult = await client.query(
+      `select schema_version from data_dump_runs where dump_month = $1`,
+      [dumpMonthLiteral],
+    )
+    const existingRow = singleRowOrThrow(
+      existingResult.rows,
+      'findOrCreateDumpRun: conflicting Dump Month row disappeared',
+    )
+    const existingSchemaVersion = encodeNonNegativeSafeInteger(
+      existingRow.schema_version,
+      'data_dump_runs.schema_version',
+    )
+    throw new CommunityDumpWorkflowError(
+      `Dump Month ${input.dumpMonth.text} is already reserved with schema version ${existingSchemaVersion}; ` +
+        `refusing requested schema version ${input.schemaVersion}`,
+    )
+  }
+  return mapDumpRunRow(runRow)
 }
 
 /** Loads one `data_dump_runs` row by its exact id, or `null` if it does not exist. */

--- a/src/db/postgres/lifecycle.ts
+++ b/src/db/postgres/lifecycle.ts
@@ -1,4 +1,4 @@
-export const EXPECTED_POSTGRES_SCHEMA_VERSION = 2
+export const EXPECTED_POSTGRES_SCHEMA_VERSION = 3
 
 export interface PostgresQueryClient {
   query: (

--- a/src/db/postgres/partitions/dump-month.ts
+++ b/src/db/postgres/partitions/dump-month.ts
@@ -26,7 +26,13 @@ export interface DumpMonthBoundsUtc {
   readonly upperBoundUtc: Date
 }
 
+export interface AdjacentJstDumpMonths {
+  readonly previous: string
+  readonly next: string
+}
+
 const dumpMonthPattern = /^([0-9]{4})-(0[1-9]|1[0-2])$/
+const jstOffsetMilliseconds = 9 * 60 * 60 * 1000
 
 export const parseDumpMonth = (value: string): DumpMonthParts => {
   const match = dumpMonthPattern.exec(value)
@@ -52,6 +58,26 @@ export const computeDumpMonthBoundsUtc = (parts: DumpMonthParts): DumpMonthBound
   return {
     lowerBoundUtc: boundary(monthIndex0),
     upperBoundUtc: boundary(monthIndex0 + 1),
+  }
+}
+
+const formatNormalizedDumpMonth = (year: number, monthIndex0: number): string => {
+  const normalized = new Date(0)
+  normalized.setUTCHours(0, 0, 0, 0)
+  normalized.setUTCFullYear(year, monthIndex0, 1)
+  return `${normalized.getUTCFullYear()}-${String(normalized.getUTCMonth() + 1).padStart(2, '0')}`
+}
+
+export const deriveAdjacentJstDumpMonths = (now: Date): AdjacentJstDumpMonths => {
+  if (Number.isNaN(now.getTime())) {
+    throw new PartitionMaintenanceError('Cannot derive Dump Months from an invalid date')
+  }
+  const jstNow = new Date(now.getTime() + jstOffsetMilliseconds)
+  const year = jstNow.getUTCFullYear()
+  const monthIndex0 = jstNow.getUTCMonth()
+  return {
+    previous: formatNormalizedDumpMonth(year, monthIndex0 - 1),
+    next: formatNormalizedDumpMonth(year, monthIndex0 + 1),
   }
 }
 

--- a/src/db/postgres/schema.ts
+++ b/src/db/postgres/schema.ts
@@ -65,7 +65,7 @@ export const dataDumpRuns = pgTable(
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().default(clockTimestamp),
   },
   (t) => [
-    unique('data_dump_runs_month_version_key').on(t.dumpMonth, t.schemaVersion),
+    unique('data_dump_runs_month_key').on(t.dumpMonth),
     check(
       'data_dump_runs_status_check',
       sql`${t.status} in ('pending', 'exporting', 'uploaded', 'published', 'cleanup_eligible', 'cleaned', 'failed')`,

--- a/src/dumps/community-dump-manifest.ts
+++ b/src/dumps/community-dump-manifest.ts
@@ -7,7 +7,7 @@ import { encodeIsoMillisecondTimestampUtc, encodeNonNegativeDecimal } from './co
  * Community Dump v1 manifest serializer (plan lines 653-685). Builds the exact
  * `CommunityDumpManifestV1` object the plan declares, always ordering `files` in registry
  * order regardless of input order so the manifest's shape is fully deterministic, and
- * rejecting any input whose dataset set is not exactly the nine expected datasets
+ * rejecting any input whose dataset set is not exactly the registered datasets
  * (missing, duplicated, or unknown/extra dataset names all fail).
  */
 

--- a/src/dumps/community-dump-object-keys.ts
+++ b/src/dumps/community-dump-object-keys.ts
@@ -2,11 +2,11 @@ import { type CommunityDumpDatasetName } from './community-dump-dataset-name'
 import { CommunityDumpError } from './community-dump-errors'
 
 /**
- * Deterministic Community Dump v1 object key derivation
+ * Deterministic Community Dump object key derivation
  * (docs/postgresql-migration-plan.md lines 646-651):
  *
- *   months/{YYYY-MM}/v{schemaVersion}/{dataset}.jsonl.zst
- *   months/{YYYY-MM}/v{schemaVersion}/manifest.json
+ *   {YYYY-MM}/{dataset}.jsonl.zst
+ *   {YYYY-MM}/manifest.json
  *
  * Deliberately backend-neutral (no PostgreSQL import), matching every other module in this
  * directory: the R2/S3 key layout is the same regardless of which database produced the data.
@@ -16,8 +16,6 @@ import { CommunityDumpError } from './community-dump-errors'
  * equally-independent copy of the same one-line YYYY-MM regex, not a reimplementation of any
  * larger module's logic.
  */
-
-export const communityDumpDataObjectSchemaVersion = 1 as const
 
 const dumpMonthPattern = /^\d{4}-(0[1-9]|1[0-2])$/
 
@@ -33,11 +31,11 @@ export const deriveCommunityDumpDataObjectKey = (
   dataset: CommunityDumpDatasetName,
 ): string => {
   assertValidDumpMonth(dumpMonth)
-  return `months/${dumpMonth}/v${communityDumpDataObjectSchemaVersion}/${dataset}.jsonl.zst`
+  return `${dumpMonth}/${dataset}.jsonl.zst`
 }
 
 /** Object key for one Dump Month's manifest (uncompressed JSON; the publication commit point). */
 export const deriveCommunityDumpManifestObjectKey = (dumpMonth: string): string => {
   assertValidDumpMonth(dumpMonth)
-  return `months/${dumpMonth}/v${communityDumpDataObjectSchemaVersion}/manifest.json`
+  return `${dumpMonth}/manifest.json`
 }

--- a/src/object-store/r2-client.ts
+++ b/src/object-store/r2-client.ts
@@ -1,6 +1,11 @@
 import { Readable } from 'stream'
 
-import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3'
 
 /**
  * Cloudflare R2 object-store configuration, loaded only from `POI_SERVER_DUMP_R2_*`
@@ -28,6 +33,11 @@ export interface S3GetObjectInput {
   readonly key: string
 }
 
+export interface S3DeleteObjectInput {
+  readonly bucket: string
+  readonly key: string
+}
+
 /**
  * Minimal structural port over the two raw S3-compatible operations the Community Dump object
  * store needs. Deliberately raw: errors propagate exactly as the underlying client throws them,
@@ -41,6 +51,10 @@ export interface S3GetObjectInput {
 export interface S3ObjectClient {
   putObject(input: S3PutObjectInput): Promise<void>
   getObject(input: S3GetObjectInput): Promise<Buffer>
+}
+
+export interface S3ConnectionCheckClient extends S3ObjectClient {
+  deleteObject(input: S3DeleteObjectInput): Promise<void>
 }
 
 const streamToBuffer = async (stream: Readable): Promise<Buffer> => {
@@ -57,7 +71,7 @@ const streamToBuffer = async (stream: Readable): Promise<Buffer> => {
  * test or e2e test in this repository uses real R2 credentials; `InMemoryObjectStore` stands in
  * everywhere else (docs/postgresql-migration-plan.md lines 638-640).
  */
-export const createS3ObjectClient = (config: R2ObjectStoreConfig): S3ObjectClient => {
+export const createS3ObjectClient = (config: R2ObjectStoreConfig): S3ConnectionCheckClient => {
   const client = new S3Client({
     region: config.region,
     endpoint: config.endpoint,
@@ -80,6 +94,9 @@ export const createS3ObjectClient = (config: R2ObjectStoreConfig): S3ObjectClien
         throw new Error(`R2 GetObject for "${key}" did not return a Node.js Readable stream body`)
       }
       return streamToBuffer(output.Body)
+    },
+    deleteObject: async ({ bucket, key }) => {
+      await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }))
     },
   }
 }

--- a/tests/community-dump-manifest.test.ts
+++ b/tests/community-dump-manifest.test.ts
@@ -18,7 +18,7 @@ const makeFile = (
   overrides: Partial<CommunityDumpManifestFileInput> = {},
 ): CommunityDumpManifestFileInput => ({
   dataset,
-  objectKey: `months/2024-01/v1/${dataset}.jsonl.zst`,
+  objectKey: `2024-01/${dataset}.jsonl.zst`,
   rowCount: 10,
   compressedBytes: 1024,
   sha256: sha256Hex,
@@ -69,7 +69,7 @@ describe('serializeCommunityDumpManifestV1', () => {
     const createShip = manifest.files.find((file) => file.dataset === 'createShipObservations')
     expect(createShip).toEqual({
       dataset: 'createShipObservations',
-      objectKey: 'months/2024-01/v1/createShipObservations.jsonl.zst',
+      objectKey: '2024-01/createShipObservations.jsonl.zst',
       rowCount: '9007199254740991',
       compressedBytes: '2048',
       sha256: sha256Hex,
@@ -293,7 +293,7 @@ describe('parseCommunityDumpManifestV1', () => {
 
   const validRawFile = {
     dataset: 'createShipObservations',
-    objectKey: 'months/2024-01/v1/createShipObservations.jsonl.zst',
+    objectKey: '2024-01/createShipObservations.jsonl.zst',
     rowCount: 10,
     compressedBytes: 1024,
     sha256: sha256Hex,

--- a/tests/community-dump-object-keys.test.ts
+++ b/tests/community-dump-object-keys.test.ts
@@ -2,30 +2,25 @@ import { describe, expect, test } from 'vitest'
 
 import { CommunityDumpError } from '../src/dumps/community-dump-errors'
 import {
-  communityDumpDataObjectSchemaVersion,
   deriveCommunityDumpDataObjectKey,
   deriveCommunityDumpManifestObjectKey,
 } from '../src/dumps/community-dump-object-keys'
 import { communityDumpDatasetNames } from '../src/dumps/community-dump-registry'
 
 /**
- * Deterministic Community Dump v1 object key derivation
+ * Deterministic Community Dump object key derivation
  * (docs/postgresql-migration-plan.md lines 646-651):
- *   months/{YYYY-MM}/v{schemaVersion}/{dataset}.jsonl.zst
- *   months/{YYYY-MM}/v{schemaVersion}/manifest.json
+ *   {YYYY-MM}/{dataset}.jsonl.zst
+ *   {YYYY-MM}/manifest.json
  */
 
 describe('deriveCommunityDumpDataObjectKey', () => {
-  test('builds the exact key layout for every one of the nine datasets', () => {
+  test('builds the exact key layout for every registered dataset', () => {
     for (const dataset of communityDumpDatasetNames) {
       expect(deriveCommunityDumpDataObjectKey('2024-01', dataset)).toBe(
-        `months/2024-01/v1/${dataset}.jsonl.zst`,
+        `2024-01/${dataset}.jsonl.zst`,
       )
     }
-  })
-
-  test('schema version constant is 1 and is embedded as "v1"', () => {
-    expect(communityDumpDataObjectSchemaVersion).toBe(1)
   })
 
   test.each([
@@ -44,7 +39,7 @@ describe('deriveCommunityDumpDataObjectKey', () => {
 
 describe('deriveCommunityDumpManifestObjectKey', () => {
   test('builds the exact manifest key layout', () => {
-    expect(deriveCommunityDumpManifestObjectKey('2024-01')).toBe(`months/2024-01/v1/manifest.json`)
+    expect(deriveCommunityDumpManifestObjectKey('2024-01')).toBe(`2024-01/manifest.json`)
   })
 
   test('rejects an invalid dumpMonth', () => {

--- a/tests/community-dump.postgres.e2e.test.ts
+++ b/tests/community-dump.postgres.e2e.test.ts
@@ -439,12 +439,11 @@ const ingestedAtFor = (dumpMonth: string): Date => {
 }
 
 /**
- * Clears every `data_dump_files`/`data_dump_runs` row for this exact `(dumpMonth,
- * schemaVersion)` natural key (FK-safe order), drops any monthly/pending partition artifact for
- * all nine Observation parents for `dumpMonth`, and clears any stray DEFAULT-partition rows for
- * the same month. Called both before and after every test so a prior interrupted run can never
- * leak into the next one, and so this suite never leaves state behind afterward. Never touches
- * `schema_metadata`.
+ * Clears the canonical `data_dump_files`/`data_dump_runs` row for this Dump Month and current schema
+ * version (FK-safe order), drops any monthly/pending partition artifact for every registered
+ * Observation parent, and clears any stray DEFAULT-partition rows for the same month. Called both
+ * before and after every test so a prior interrupted run can never leak into the next one, and so
+ * this suite never leaves state behind afterward. Never touches `schema_metadata`.
  */
 const resetDumpMonthArtifacts = async (dumpMonth: string): Promise<void> => {
   const parts = parseDumpMonth(dumpMonth)

--- a/tests/dump-cleanup-workflow.test.ts
+++ b/tests/dump-cleanup-workflow.test.ts
@@ -7,6 +7,7 @@ import {
   CommunityDumpPreconditionError,
   CommunityDumpVerificationMismatchError,
 } from '../src/db/postgres/dumps/errors'
+import { EXPECTED_POSTGRES_SCHEMA_VERSION } from '../src/db/postgres/lifecycle'
 import {
   type PartitionPool,
   type PartitionQueryResult,
@@ -256,7 +257,7 @@ const createFakeCleanupDatabase = (
   clients: Array<{ release: ReturnType<typeof vi.fn> }>
 } => {
   const database: FakeDatabase = {
-    schemaVersion: 2,
+    schemaVersion: EXPECTED_POSTGRES_SCHEMA_VERSION,
     run: options.run === undefined ? buildHappyRun() : options.run,
     files: options.files ?? buildHappyFiles(),
     now: options.now ?? cleanupEligibleAt,
@@ -421,7 +422,7 @@ describe('cleanupDumpRun', () => {
 
   test('rejects a run whose manifest object key is not the deterministic key for its month', async () => {
     const { pool } = createFakeCleanupDatabase({
-      run: buildHappyRun({ manifestObjectKey: 'months/wrong/manifest.json' }),
+      run: buildHappyRun({ manifestObjectKey: 'wrong/manifest.json' }),
     })
 
     await expect(cleanupDumpRun(pool, buildHappyObjectStore(), runId)).rejects.toThrow(
@@ -511,7 +512,7 @@ describe('cleanupDumpRun', () => {
 
   test('rejects when a data_dump_files row has the wrong immutable object key', async () => {
     const files = buildHappyFiles()
-    files[0] = { ...files[0], objectKey: 'months/2024-01/v1/wrong.jsonl.zst' }
+    files[0] = { ...files[0], objectKey: '2024-01/wrong.jsonl.zst' }
     const { pool } = createFakeCleanupDatabase({ files })
     const objectStore = buildHappyObjectStore()
 

--- a/tests/dump-run-repository.test.ts
+++ b/tests/dump-run-repository.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../src/db/postgres/dumps/errors'
 import {
   findOrCreateDumpRun,
+  listCleanupEligibleDumpRuns,
   listDumpFilesByRunId,
   listDumpFilesByRunIdForUpdate,
   loadDatabaseNow,
@@ -165,6 +166,49 @@ describe('loadDumpRunById', () => {
     const result = await loadDumpRunById(client, 999)
 
     expect(result).toBeNull()
+  })
+})
+
+describe('listCleanupEligibleDumpRuns', () => {
+  test('uses the database clock and returns eligible published runs in cleanup order', async () => {
+    const firstEligibleAt = new Date('2024-02-08T00:00:00.000Z')
+    const secondEligibleAt = new Date('2024-03-08T00:00:00.000Z')
+    const client = createFakeClient(async () => ({
+      rows: [
+        runRow({
+          id: '7',
+          status: 'published',
+          cleanup_eligible_at: firstEligibleAt,
+        }),
+        runRow({
+          id: '8',
+          dump_month: '2024-02',
+          status: 'cleanup_eligible',
+          cleanup_eligible_at: secondEligibleAt,
+        }),
+      ],
+      rowCount: 2,
+    }))
+
+    const result = await listCleanupEligibleDumpRuns(client)
+
+    const [sql, values] = vi.mocked(client.query).mock.calls[0]
+    expect(sql).toContain("status in ('published', 'cleanup_eligible')")
+    expect(sql).toContain('cleanup_eligible_at <= clock_timestamp()')
+    expect(sql).toContain('order by cleanup_eligible_at, id')
+    expect(values).toBeUndefined()
+    expect(result).toEqual([
+      expectedRunRow({
+        status: 'published',
+        cleanupEligibleAt: firstEligibleAt,
+      }),
+      expectedRunRow({
+        id: 8,
+        dumpMonth: '2024-02',
+        status: 'cleanup_eligible',
+        cleanupEligibleAt: secondEligibleAt,
+      }),
+    ])
   })
 })
 

--- a/tests/dump-run-repository.test.ts
+++ b/tests/dump-run-repository.test.ts
@@ -72,7 +72,7 @@ const fileRow = (overrides: Record<string, unknown> = {}): Record<string, unknow
   dump_run_id: '7',
   dataset: 'createShipObservations',
   partition_name: 'create_ship_records_2024_01',
-  object_key: 'months/2024-01/v1/createShipObservations.jsonl.zst',
+  object_key: '2024-01/createShipObservations.jsonl.zst',
   row_count: '12345',
   compressed_bytes: '987654',
   sha256: Buffer.from('a'.repeat(64), 'hex'),
@@ -85,7 +85,7 @@ const expectedFileRow = (overrides: Partial<DumpFileRow> = {}): DumpFileRow => (
   dumpRunId: 7,
   dataset: 'createShipObservations',
   partitionName: 'create_ship_records_2024_01',
-  objectKey: 'months/2024-01/v1/createShipObservations.jsonl.zst',
+  objectKey: '2024-01/createShipObservations.jsonl.zst',
   rowCount: 12345,
   compressedBytes: 987654,
   sha256: 'a'.repeat(64),
@@ -114,7 +114,10 @@ describe('findOrCreateDumpRun', () => {
     const [sql, values] = vi.mocked(client.query).mock.calls[0]
     expect(sql).toContain('insert into data_dump_runs')
     expect(sql).toContain('on conflict')
+    expect(sql).toContain('on conflict (dump_month)')
+    expect(sql).not.toContain('on conflict (dump_month, schema_version)')
     expect(sql.toLowerCase()).toContain('do update')
+    expect(sql).toContain('where data_dump_runs.schema_version = excluded.schema_version')
     expect(values).toEqual(['2024-01-01', 1])
     expect(result).toEqual(expectedRunRow())
   })
@@ -133,6 +136,25 @@ describe('findOrCreateDumpRun', () => {
     expect(result).toEqual(
       expectedRunRow({ status: 'exporting', error: 'previous attempt failed mid-export' }),
     )
+  })
+
+  test('rejects a different schema version for an already-reserved Dump Month', async () => {
+    const client = createFakeClient(async (text) =>
+      text.startsWith('insert')
+        ? emptyResult
+        : {
+            rows: [{ schema_version: 2 }],
+            rowCount: 1,
+          },
+    )
+
+    await expect(
+      findOrCreateDumpRun(client, {
+        dumpMonth: parseDumpMonth('2024-01'),
+        schemaVersion: 1,
+      }),
+    ).rejects.toThrow(/already reserved with schema version 2/)
+    expect(client.query).toHaveBeenCalledTimes(2)
   })
 
   test('throws when the database returns no row at all', async () => {
@@ -362,7 +384,7 @@ describe('recordManifestMetadata', () => {
       rows: [
         runRow({
           status: 'uploaded',
-          manifest_object_key: 'months/2024-01/v1/manifest.json',
+          manifest_object_key: '2024-01/manifest.json',
           manifest_bytes: '4096',
           manifest_sha256: Buffer.from(sha256Hex, 'hex'),
         }),
@@ -371,7 +393,7 @@ describe('recordManifestMetadata', () => {
     }))
 
     const result = await recordManifestMetadata(client, 7, {
-      objectKey: 'months/2024-01/v1/manifest.json',
+      objectKey: '2024-01/manifest.json',
       bytes: 4096,
       sha256Hex,
     })
@@ -382,14 +404,14 @@ describe('recordManifestMetadata', () => {
     expect(sql).toContain('manifest_bytes')
     expect(sql).toContain('manifest_sha256')
     expect(values?.[0]).toBe(7)
-    expect(values?.[1]).toBe('months/2024-01/v1/manifest.json')
+    expect(values?.[1]).toBe('2024-01/manifest.json')
     expect(values?.[2]).toBe(4096)
     expect(Buffer.isBuffer(values?.[3])).toBe(true)
     expect((values?.[3] as Buffer).toString('hex')).toBe(sha256Hex)
     expect(result).toEqual(
       expectedRunRow({
         status: 'uploaded',
-        manifestObjectKey: 'months/2024-01/v1/manifest.json',
+        manifestObjectKey: '2024-01/manifest.json',
         manifestBytes: 4096,
         manifestSha256: sha256Hex,
       }),
@@ -454,7 +476,7 @@ describe('recordDumpFileExport', () => {
       dumpRunId: 7,
       dataset: 'createShipObservations',
       partitionName: 'create_ship_records_2024_01',
-      objectKey: 'months/2024-01/v1/createShipObservations.jsonl.zst',
+      objectKey: '2024-01/createShipObservations.jsonl.zst',
       rowCount: 12345,
       compressedBytes: 987654,
       sha256Hex: 'a'.repeat(64),
@@ -485,7 +507,7 @@ describe('recordDumpFileExport', () => {
       dumpRunId: 7,
       dataset: 'createShipObservations',
       partitionName: 'create_ship_records_2024_01',
-      objectKey: 'months/2024-01/v1/createShipObservations.jsonl.zst',
+      objectKey: '2024-01/createShipObservations.jsonl.zst',
       rowCount: 12345,
       compressedBytes: 987654,
       sha256Hex: 'a'.repeat(64),
@@ -510,7 +532,7 @@ describe('recordDumpFileExport', () => {
       dumpRunId: 7,
       dataset: 'createShipObservations',
       partitionName: 'create_ship_records_2024_01',
-      objectKey: 'months/2024-01/v1/createShipObservations.jsonl.zst',
+      objectKey: '2024-01/createShipObservations.jsonl.zst',
       rowCount: 12345,
       compressedBytes: 987654,
       sha256Hex: 'a'.repeat(64),
@@ -541,7 +563,7 @@ describe('recordDumpFileExport', () => {
         dumpRunId: 7,
         dataset: 'createShipObservations',
         partitionName: 'create_ship_records_2024_01',
-        objectKey: 'months/2024-01/v1/createShipObservations.jsonl.zst',
+        objectKey: '2024-01/createShipObservations.jsonl.zst',
         rowCount: 12345,
         compressedBytes: 987654,
         sha256Hex: 'a'.repeat(64),

--- a/tests/monthly-dump-cron.test.ts
+++ b/tests/monthly-dump-cron.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'fs'
+import path from 'path'
+import { describe, expect, test } from 'vitest'
+
+describe('monthly dump cron scripts', () => {
+  const installer = readFileSync(path.resolve(__dirname, '../setup-monthly-dump-cron'), 'utf8')
+  const runner = readFileSync(path.resolve(__dirname, '../run-monthly-dump-maintenance'), 'utf8')
+
+  test('installs an idempotent managed crontab block without discarding unrelated entries', () => {
+    expect(installer).toContain('# BEGIN poi-server monthly dump')
+    expect(installer).toContain('# END poi-server monthly dump')
+    expect(installer).toContain('!managed { print }')
+    expect(installer).toContain('crontab -u "$CRON_USER" "$new_crontab"')
+  })
+
+  test('uses JST scheduling, overlap prevention, and persistent logs', () => {
+    expect(installer).toContain('CRON_TZ=Asia/Tokyo')
+    expect(installer).toContain('./run-monthly-dump-maintenance')
+    expect(installer).toContain('>> %s 2>&1')
+    expect(runner).toContain('flock -n 9')
+    expect(runner).toContain('status=skipped reason=overlap')
+    expect(runner).toContain('timeout --foreground "$TIMEOUT"')
+  })
+
+  test('runner records start, success, and failure context without shell tracing', () => {
+    expect(runner).toContain('status=started')
+    expect(runner).toContain('status=succeeded elapsed_seconds=$elapsed_seconds')
+    expect(runner).toContain('status=failed exit_code=$exit_code elapsed_seconds=$elapsed_seconds')
+    expect(runner).toContain('npm run --silent db:dumps:maintain')
+    expect(runner).not.toMatch(/\bset -x\b/)
+  })
+
+  test('rejects malformed managed blocks and prepares custom lock directories', () => {
+    expect(installer).toContain('existing monthly dump crontab markers are malformed')
+    expect(installer).toContain('if [ ! -d "$(dirname "$LOCK_FILE")" ]')
+    expect(installer).toContain('POI_DUMP_CRON_TIMEOUT')
+  })
+})

--- a/tests/monthly-dump-cron.test.ts
+++ b/tests/monthly-dump-cron.test.ts
@@ -56,4 +56,17 @@ describe('monthly dump cron scripts', () => {
       '[[ -x "$APP_DIR/fnm-exec" ]] || fail "$APP_DIR/fnm-exec is not executable"',
     )
   })
+
+  test('validates the exact GNU and util-linux capabilities used by cron', () => {
+    for (const script of [installer, runner]) {
+      expect(script).toContain(
+        'date --iso-8601=seconds >/dev/null 2>&1 || fail "GNU date with --iso-8601=seconds is required"',
+      )
+      expect(script).toContain(
+        'flock --version >/dev/null 2>&1 || fail "util-linux flock is required"',
+      )
+      expect(script).toContain('timeout --foreground -- 1s true >/dev/null 2>&1')
+      expect(script).toContain('fail "GNU timeout with --foreground is required"')
+    }
+  })
 })

--- a/tests/monthly-dump-cron.test.ts
+++ b/tests/monthly-dump-cron.test.ts
@@ -37,12 +37,19 @@ describe('monthly dump cron scripts', () => {
     expect(installer).toContain('POI_DUMP_CRON_TIMEOUT')
   })
 
-  test('rejects leading-dash paths and validates direct runner overrides', () => {
-    const safePathPattern = String.raw`safe_path_pattern='^[/._A-Za-z0-9][A-Za-z0-9_./-]*$'`
-    expect(installer).toContain(safePathPattern)
-    expect(runner).toContain(safePathPattern)
-    expect(runner).toContain('POI_DUMP_CRON_APP_DIR contains unsupported characters')
-    expect(runner).toContain('POI_DUMP_CRON_LOCK_FILE contains unsupported characters')
+  test('requires absolute paths and validates direct runner overrides', () => {
+    const absolutePathPattern = String.raw`absolute_path_pattern='^/[A-Za-z0-9_./-]*$'`
+    expect(installer).toContain(absolutePathPattern)
+    expect(runner).toContain(absolutePathPattern)
+    expect(runner).toContain(
+      'POI_DUMP_CRON_APP_DIR must be an absolute path with supported characters',
+    )
+    expect(runner).toContain(
+      'POI_DUMP_CRON_LOCK_FILE must be an absolute path with supported characters',
+    )
+    expect(installer).toContain(
+      'POI_DUMP_CRON_LOG_FILE must be an absolute path with supported characters',
+    )
     expect(runner).toContain(
       'POI_DUMP_CRON_TIMEOUT must be a positive duration ending in s, m, h, or d',
     )

--- a/tests/monthly-dump-cron.test.ts
+++ b/tests/monthly-dump-cron.test.ts
@@ -3,8 +3,8 @@ import path from 'path'
 import { describe, expect, test } from 'vitest'
 
 describe('monthly dump cron scripts', () => {
-  const installer = readFileSync(path.resolve(__dirname, '../setup-monthly-dump-cron'), 'utf8')
-  const runner = readFileSync(path.resolve(__dirname, '../run-monthly-dump-maintenance'), 'utf8')
+  const installer = readFileSync(path.resolve(__dirname, '../setup-monthly-dump-cron.sh'), 'utf8')
+  const runner = readFileSync(path.resolve(__dirname, '../run-monthly-dump-maintenance.sh'), 'utf8')
 
   test('installs an idempotent managed crontab block without discarding unrelated entries', () => {
     expect(installer).toContain('# BEGIN poi-server monthly dump')
@@ -15,11 +15,11 @@ describe('monthly dump cron scripts', () => {
 
   test('uses JST scheduling, overlap prevention, and persistent logs', () => {
     expect(installer).toContain('CRON_TZ=Asia/Tokyo')
-    expect(installer).toContain('./run-monthly-dump-maintenance')
+    expect(installer).toContain('./run-monthly-dump-maintenance.sh')
     expect(installer).toContain('>> %s 2>&1')
     expect(runner).toContain('flock -n 9')
     expect(runner).toContain('status=skipped reason=overlap')
-    expect(runner).toContain('timeout --foreground "$TIMEOUT"')
+    expect(runner).toContain('timeout --foreground -- "$TIMEOUT"')
   })
 
   test('runner records start, success, and failure context without shell tracing', () => {
@@ -27,6 +27,7 @@ describe('monthly dump cron scripts', () => {
     expect(runner).toContain('status=succeeded elapsed_seconds=$elapsed_seconds')
     expect(runner).toContain('status=failed exit_code=$exit_code elapsed_seconds=$elapsed_seconds')
     expect(runner).toContain('npm run --silent db:dumps:maintain')
+    expect(runner).toContain('cd -- "$APP_DIR"')
     expect(runner).not.toMatch(/\bset -x\b/)
   })
 
@@ -34,5 +35,16 @@ describe('monthly dump cron scripts', () => {
     expect(installer).toContain('existing monthly dump crontab markers are malformed')
     expect(installer).toContain('if [ ! -d "$(dirname "$LOCK_FILE")" ]')
     expect(installer).toContain('POI_DUMP_CRON_TIMEOUT')
+  })
+
+  test('rejects leading-dash paths and validates direct runner overrides', () => {
+    const safePathPattern = String.raw`safe_path_pattern='^[/._A-Za-z0-9][A-Za-z0-9_./-]*$'`
+    expect(installer).toContain(safePathPattern)
+    expect(runner).toContain(safePathPattern)
+    expect(runner).toContain('POI_DUMP_CRON_APP_DIR contains unsupported characters')
+    expect(runner).toContain('POI_DUMP_CRON_LOCK_FILE contains unsupported characters')
+    expect(runner).toContain(
+      'POI_DUMP_CRON_TIMEOUT must be a positive duration ending in s, m, h, or d',
+    )
   })
 })

--- a/tests/monthly-dump-cron.test.ts
+++ b/tests/monthly-dump-cron.test.ts
@@ -47,4 +47,13 @@ describe('monthly dump cron scripts', () => {
       'POI_DUMP_CRON_TIMEOUT must be a positive duration ending in s, m, h, or d',
     )
   })
+
+  test('validates the deployment runtime before installing or running maintenance', () => {
+    expect(installer).toContain(
+      '[[ -x "$APP_DIR/fnm-exec" ]] || fail "$APP_DIR/fnm-exec is not executable"',
+    )
+    expect(runner).toContain(
+      '[[ -x "$APP_DIR/fnm-exec" ]] || fail "$APP_DIR/fnm-exec is not executable"',
+    )
+  })
 })

--- a/tests/partition-dump-month.test.ts
+++ b/tests/partition-dump-month.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest'
 import { observationParentTables } from '../src/db/postgres/partitions/observation-tables'
 import {
   computeDumpMonthBoundsUtc,
+  deriveAdjacentJstDumpMonths,
   deriveDefaultPartitionName,
   deriveMonthlyPartitionName,
   derivePendingPartitionName,
@@ -42,6 +43,23 @@ describe('parseDumpMonth', () => {
   ])('rejects the malformed Dump Month %s (%s)', (value) => {
     expect(() => parseDumpMonth(value)).toThrow(PartitionMaintenanceError)
     expect(() => parseDumpMonth(value)).toThrow(/YYYY-MM/)
+  })
+})
+
+describe('deriveAdjacentJstDumpMonths', () => {
+  test.each([
+    ['2026-07-31T14:59:59.999Z', '2026-06', '2026-08'],
+    ['2026-07-31T15:00:00.000Z', '2026-07', '2026-09'],
+    ['2026-12-31T15:00:00.000Z', '2026-12', '2027-02'],
+    ['2026-01-01T00:00:00.000Z', '2025-12', '2026-02'],
+  ])('derives the previous closed and next upcoming JST months at %s', (now, previous, next) => {
+    expect(deriveAdjacentJstDumpMonths(new Date(now))).toEqual({ previous, next })
+  })
+
+  test('rejects an invalid date', () => {
+    expect(() => deriveAdjacentJstDumpMonths(new Date(Number.NaN))).toThrow(
+      PartitionMaintenanceError,
+    )
   })
 })
 

--- a/tests/postgres-dump-maintenance-command.test.ts
+++ b/tests/postgres-dump-maintenance-command.test.ts
@@ -18,6 +18,8 @@ const fakeR2Env = {
   POI_SERVER_DUMP_R2_ACCESS_KEY_ID: 'the-access-key-id',
   POI_SERVER_DUMP_R2_SECRET_ACCESS_KEY: 'the-super-secret-value',
 }
+const fakeDatabasePassword = 'db-password-for-test'
+const fakeDatabaseUrl = `postgresql://poi:${fakeDatabasePassword}@localhost:5432/poi`
 
 const publishedRun: DumpRunRow = {
   id: 9,
@@ -62,7 +64,7 @@ const makeFakeDeps = (
   const deps: DumpMaintenanceCommandDeps = {
     resolveDatabaseUrl: () => {
       calls.push('resolveDatabaseUrl')
-      return '******localhost:5432/poi'
+      return fakeDatabaseUrl
     },
     resolveDatabaseBackend: () => {
       calls.push('resolveDatabaseBackend')
@@ -222,7 +224,7 @@ describe('runDumpMaintenanceCommand', () => {
     const { deps } = makeFakeDeps({
       publishDumpMonth: async () => {
         throw new Error(
-          'failed at ******localhost/poi with the-access-key-id and the-super-secret-value',
+          `failed with ${fakeDatabasePassword}, the-access-key-id, and the-super-secret-value`,
         )
       },
     })
@@ -235,7 +237,7 @@ describe('runDumpMaintenanceCommand', () => {
     }
 
     expect(thrown?.message).toContain('<redacted>')
-    expect(thrown?.message).not.toContain('the-db-password')
+    expect(thrown?.message).not.toContain(fakeDatabasePassword)
     expect(thrown?.message).not.toContain('the-access-key-id')
     expect(thrown?.message).not.toContain('the-super-secret-value')
   })

--- a/tests/postgres-dump-maintenance-command.test.ts
+++ b/tests/postgres-dump-maintenance-command.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import {
+  defaultDumpMaintenanceCommandDeps,
+  dumpMaintenanceCommandUsage,
+  runDumpMaintenanceCommand,
+  type DumpMaintenanceCommandDeps,
+} from '../src/cli/postgres-dump-maintenance-command'
+import { type CleanupDumpRunResult } from '../src/db/postgres/dumps/cleanup-dump-run'
+import { type DumpPool } from '../src/db/postgres/dumps/adapter'
+import { type DumpRunRow } from '../src/db/postgres/dumps/dump-run-repository'
+import { type PartitionPoolClient } from '../src/db/postgres/partitions/adapter'
+import { loadR2ObjectStoreConfigFromEnv } from '../src/object-store/r2-object-store'
+
+const fakeR2Env = {
+  POI_SERVER_DUMP_R2_ENDPOINT: 'https://account-id.r2.cloudflarestorage.com',
+  POI_SERVER_DUMP_R2_BUCKET: 'community-dumps',
+  POI_SERVER_DUMP_R2_ACCESS_KEY_ID: 'the-access-key-id',
+  POI_SERVER_DUMP_R2_SECRET_ACCESS_KEY: 'the-super-secret-value',
+}
+
+const publishedRun: DumpRunRow = {
+  id: 9,
+  dumpMonth: '2026-07',
+  schemaVersion: 1,
+  status: 'published',
+  manifestObjectKey: 'months/2026-07/v1/manifest.json',
+  manifestBytes: 10,
+  manifestSha256: 'a'.repeat(64),
+  publishedAt: new Date('2026-08-01T00:00:00.000Z'),
+  cleanupEligibleAt: new Date('2026-08-08T00:00:00.000Z'),
+  cleanedAt: null,
+  error: null,
+}
+
+const eligibleRuns: readonly DumpRunRow[] = [
+  { ...publishedRun, id: 7, dumpMonth: '2026-05' },
+  { ...publishedRun, id: 8, dumpMonth: '2026-06' },
+]
+
+const makeFakeDeps = (
+  overrides: Partial<DumpMaintenanceCommandDeps> = {},
+): {
+  deps: DumpMaintenanceCommandDeps
+  calls: string[]
+  pool: { end: ReturnType<typeof vi.fn> }
+  client: PartitionPoolClient
+} => {
+  const calls: string[] = []
+  const client: PartitionPoolClient = {
+    query: vi.fn(),
+    release: vi.fn(() => calls.push('release')),
+  }
+  const dumpPool: DumpPool = {
+    connect: vi.fn(async () => {
+      calls.push('connect')
+      return { ...client, streamQuery: vi.fn() }
+    }),
+  }
+  const pool = { end: vi.fn() }
+
+  const deps: DumpMaintenanceCommandDeps = {
+    resolveDatabaseUrl: () => {
+      calls.push('resolveDatabaseUrl')
+      return '******localhost:5432/poi'
+    },
+    resolveDatabaseBackend: () => {
+      calls.push('resolveDatabaseBackend')
+      return 'postgresql'
+    },
+    loadR2Config: () => {
+      calls.push('loadR2Config')
+      return loadR2ObjectStoreConfigFromEnv(fakeR2Env)
+    },
+    createObjectStore: () => {
+      calls.push('createObjectStore')
+      return { putIfAbsent: vi.fn(), getObject: vi.fn() }
+    },
+    createOfflineDumpPool: () => {
+      calls.push('createOfflineDumpPool')
+      return pool as never
+    },
+    createDumpPoolFromPgPool: () => {
+      calls.push('createDumpPoolFromPgPool')
+      return dumpPool
+    },
+    endPool: async () => {
+      calls.push('endPool')
+      await pool.end()
+    },
+    now: () => new Date('2026-08-01T00:30:00.000+09:00'),
+    createUpcomingMonthPartitions: async (_pool, month) => {
+      calls.push(`createUpcomingMonthPartitions:${month}`)
+      return [
+        {
+          table: 'create_ship_records',
+          partitionName: 'create_ship_records_2026_09',
+          action: 'created',
+        },
+      ]
+    },
+    publishDumpMonth: async (_pool, _store, month) => {
+      calls.push(`publishDumpMonth:${month}`)
+      return publishedRun
+    },
+    listCleanupEligibleDumpRuns: async () => {
+      calls.push('listCleanupEligibleDumpRuns')
+      return eligibleRuns
+    },
+    cleanupDumpRun: async (_pool, _store, runId) => {
+      if (typeof runId !== 'number') {
+        throw new Error('expected a numeric run id')
+      }
+      calls.push(`cleanupDumpRun:${runId}`)
+      const result: CleanupDumpRunResult = {
+        runId,
+        action: 'cleaned',
+        partitionsDropped: [`partition_${runId}`],
+      }
+      return result
+    },
+    ...overrides,
+  }
+
+  return { deps, calls, pool, client }
+}
+
+describe('runDumpMaintenanceCommand', () => {
+  test('creates next-month partitions, publishes the previous month, and cleans every eligible run', async () => {
+    const { deps, calls, pool, client } = makeFakeDeps()
+
+    const result = await runDumpMaintenanceCommand([], {}, deps)
+
+    expect(result.previousDumpMonth).toBe('2026-07')
+    expect(result.upcomingDumpMonth).toBe('2026-09')
+    expect(result.publishedRun).toBe(publishedRun)
+    expect(result.cleanups.map((cleanup) => cleanup.runId)).toEqual([7, 8])
+    expect(calls).toEqual([
+      'resolveDatabaseUrl',
+      'resolveDatabaseBackend',
+      'loadR2Config',
+      'createObjectStore',
+      'createOfflineDumpPool',
+      'createDumpPoolFromPgPool',
+      'createUpcomingMonthPartitions:2026-09',
+      'publishDumpMonth:2026-07',
+      'connect',
+      'listCleanupEligibleDumpRuns',
+      'release',
+      'cleanupDumpRun:7',
+      'cleanupDumpRun:8',
+      'endPool',
+    ])
+    expect(client.release).toHaveBeenCalledOnce()
+    expect(pool.end).toHaveBeenCalledOnce()
+  })
+
+  test('rejects arguments before touching configuration or infrastructure', async () => {
+    const { deps, calls } = makeFakeDeps()
+
+    await expect(runDumpMaintenanceCommand(['unexpected'], {}, deps)).rejects.toThrow(/Usage/)
+
+    expect(calls).toEqual([])
+  })
+
+  test('requires PostgreSQL before loading R2 configuration or opening a pool', async () => {
+    const { deps, calls } = makeFakeDeps({
+      resolveDatabaseBackend: () => {
+        calls.push('resolveDatabaseBackend')
+        return 'mongodb'
+      },
+    })
+
+    await expect(runDumpMaintenanceCommand([], {}, deps)).rejects.toThrow(
+      /requires a postgres: or postgresql: database URL/,
+    )
+    expect(calls).toEqual(['resolveDatabaseUrl', 'resolveDatabaseBackend'])
+  })
+
+  test('releases the listing client and ends the pool when cleanup discovery fails', async () => {
+    const { deps, pool, client } = makeFakeDeps({
+      listCleanupEligibleDumpRuns: async () => {
+        throw new Error('discovery failed')
+      },
+    })
+
+    await expect(runDumpMaintenanceCommand([], {}, deps)).rejects.toThrow('discovery failed')
+
+    expect(client.release).toHaveBeenCalledOnce()
+    expect(pool.end).toHaveBeenCalledOnce()
+  })
+
+  test('attempts independent phases and later cleanups after earlier failures', async () => {
+    const cleanup = vi.fn(async (_pool, _store, runId: unknown): Promise<CleanupDumpRunResult> => {
+      if (runId === 7) {
+        throw new Error('first cleanup failed')
+      }
+      if (typeof runId !== 'number') {
+        throw new Error('expected a numeric run id')
+      }
+      return { runId, action: 'cleaned', partitionsDropped: [] }
+    })
+    const publish = vi.fn(async () => publishedRun)
+    const { deps, pool } = makeFakeDeps({
+      createUpcomingMonthPartitions: async () => {
+        throw new Error('partition creation failed')
+      },
+      publishDumpMonth: publish,
+      cleanupDumpRun: cleanup,
+    })
+
+    await expect(runDumpMaintenanceCommand([], {}, deps)).rejects.toThrow(
+      /create upcoming partitions.*partition creation failed[\s\S]*clean dump run 7.*first cleanup failed/,
+    )
+
+    expect(publish).toHaveBeenCalledOnce()
+    expect(cleanup.mock.calls.map((call) => call[2])).toEqual([7, 8])
+    expect(pool.end).toHaveBeenCalledOnce()
+  })
+
+  test('redacts database and R2 secrets from maintenance failures', async () => {
+    const { deps } = makeFakeDeps({
+      publishDumpMonth: async () => {
+        throw new Error(
+          'failed at ******localhost/poi with the-access-key-id and the-super-secret-value',
+        )
+      },
+    })
+
+    let thrown: Error | undefined
+    try {
+      await runDumpMaintenanceCommand([], {}, deps)
+    } catch (error) {
+      thrown = error as Error
+    }
+
+    expect(thrown?.message).toContain('<redacted>')
+    expect(thrown?.message).not.toContain('the-db-password')
+    expect(thrown?.message).not.toContain('the-access-key-id')
+    expect(thrown?.message).not.toContain('the-super-secret-value')
+  })
+})
+
+describe('defaultDumpMaintenanceCommandDeps', () => {
+  test('wires the production maintenance functions', () => {
+    expect(defaultDumpMaintenanceCommandDeps.now()).toBeInstanceOf(Date)
+    expect(defaultDumpMaintenanceCommandDeps.listCleanupEligibleDumpRuns).toBeTypeOf('function')
+    expect(defaultDumpMaintenanceCommandDeps.cleanupDumpRun).toBeTypeOf('function')
+  })
+})
+
+test('dumpMaintenanceCommandUsage documents the no-argument command', () => {
+  expect(dumpMaintenanceCommandUsage).toBe('db:dumps:maintain')
+})

--- a/tests/postgres-dump-maintenance-command.test.ts
+++ b/tests/postgres-dump-maintenance-command.test.ts
@@ -26,7 +26,7 @@ const publishedRun: DumpRunRow = {
   dumpMonth: '2026-07',
   schemaVersion: 1,
   status: 'published',
-  manifestObjectKey: 'months/2026-07/v1/manifest.json',
+  manifestObjectKey: '2026-07/manifest.json',
   manifestBytes: 10,
   manifestSha256: 'a'.repeat(64),
   publishedAt: new Date('2026-08-01T00:00:00.000Z'),

--- a/tests/postgres-dump-maintenance-command.test.ts
+++ b/tests/postgres-dump-maintenance-command.test.ts
@@ -140,11 +140,11 @@ describe('runDumpMaintenanceCommand', () => {
     expect(calls).toEqual([
       'resolveDatabaseUrl',
       'resolveDatabaseBackend',
-      'loadR2Config',
-      'createObjectStore',
       'createOfflineDumpPool',
       'createDumpPoolFromPgPool',
       'createUpcomingMonthPartitions:2026-09',
+      'loadR2Config',
+      'createObjectStore',
       'publishDumpMonth:2026-07',
       'connect',
       'listCleanupEligibleDumpRuns',
@@ -177,6 +177,29 @@ describe('runDumpMaintenanceCommand', () => {
       /requires a postgres: or postgresql: database URL/,
     )
     expect(calls).toEqual(['resolveDatabaseUrl', 'resolveDatabaseBackend'])
+  })
+
+  test('still creates upcoming partitions when R2 configuration is unavailable', async () => {
+    const createPartitions = vi.fn(async () => [])
+    const publish = vi.fn(async () => publishedRun)
+    const discover = vi.fn(async () => eligibleRuns)
+    const { deps, pool } = makeFakeDeps({
+      createUpcomingMonthPartitions: createPartitions,
+      loadR2Config: () => {
+        throw new Error('R2 credentials are missing')
+      },
+      publishDumpMonth: publish,
+      listCleanupEligibleDumpRuns: discover,
+    })
+
+    await expect(runDumpMaintenanceCommand([], {}, deps)).rejects.toThrow(
+      /initialize R2 object store: R2 credentials are missing/,
+    )
+
+    expect(createPartitions).toHaveBeenCalledWith(pool, '2026-09')
+    expect(publish).not.toHaveBeenCalled()
+    expect(discover).not.toHaveBeenCalled()
+    expect(pool.end).toHaveBeenCalledOnce()
   })
 
   test('releases the listing client and ends the pool when cleanup discovery fails', async () => {

--- a/tests/postgres-lifecycle.test.ts
+++ b/tests/postgres-lifecycle.test.ts
@@ -18,7 +18,7 @@ describe('PostgreSQL startup lifecycle', () => {
 
   test.each([
     [{ rows: [] }, 'schema metadata is missing'],
-    [{ rows: [{ version: 0 }] }, 'expected schema version 2 but found 0'],
+    [{ rows: [{ version: 0 }] }, 'expected schema version 3 but found 0'],
   ])('rejects an incompatible schema', async (schemaResult, message) => {
     const client = createQueryClient([schemaResult])
 

--- a/tests/postgres-schema.test.ts
+++ b/tests/postgres-schema.test.ts
@@ -80,4 +80,16 @@ describe('PostgreSQL schema contract', () => {
       'INSERT INTO "schema_metadata" ("singleton", "version") VALUES (true, 1)',
     )
   })
+
+  test('latest migration enforces one canonical dump run per month', () => {
+    const migration = readFileSync(
+      path.resolve(__dirname, '../drizzle/0002_canonical_dump_month.sql'),
+      'utf8',
+    )
+
+    expect(migration).toContain('ADD CONSTRAINT "data_dump_runs_month_key" UNIQUE("dump_month")')
+    expect(migration).toContain('HAVING count(*) > 1')
+    expect(migration).toContain('Cannot enforce one canonical data_dump_runs row per dump_month')
+    expect(migration).toContain('SET "version" = 3')
+  })
 })

--- a/tests/r2-connection-check-command.test.ts
+++ b/tests/r2-connection-check-command.test.ts
@@ -1,0 +1,182 @@
+import { createHash } from 'crypto'
+
+import { describe, expect, test, vi } from 'vitest'
+
+import {
+  defaultR2ConnectionCheckCommandDeps,
+  r2ConnectionCheckCommandUsage,
+  runR2ConnectionCheckCommand,
+  type R2ConnectionCheckCommandDeps,
+} from '../src/cli/r2-connection-check-command'
+import {
+  createS3ObjectClient,
+  type R2ObjectStoreConfig,
+  type S3ConnectionCheckClient,
+  type S3DeleteObjectInput,
+  type S3GetObjectInput,
+  type S3PutObjectInput,
+} from '../src/object-store/r2-client'
+import { loadR2ObjectStoreConfigFromEnv } from '../src/object-store/r2-object-store'
+
+const config: R2ObjectStoreConfig = {
+  endpoint: 'https://account-id.r2.cloudflarestorage.com',
+  bucket: 'community-dumps',
+  accessKeyId: 'connection-check-access-key',
+  secretAccessKey: 'connection-check-secret-key',
+  region: 'auto',
+  forcePathStyle: true,
+}
+
+const probeKey = 'healthchecks/poi-server/r2-connection/test-id'
+const probeBody = Buffer.from('temporary R2 connection check')
+
+interface FakeClientOptions {
+  readonly putError?: Error
+  readonly getError?: Error
+  readonly getBody?: Buffer
+  readonly deleteError?: Error
+}
+
+const makeDeps = (
+  options: FakeClientOptions = {},
+  overrides: Partial<R2ConnectionCheckCommandDeps> = {},
+): {
+  deps: R2ConnectionCheckCommandDeps
+  putCalls: S3PutObjectInput[]
+  getCalls: S3GetObjectInput[]
+  deleteCalls: S3DeleteObjectInput[]
+} => {
+  const putCalls: S3PutObjectInput[] = []
+  const getCalls: S3GetObjectInput[] = []
+  const deleteCalls: S3DeleteObjectInput[] = []
+  const client: S3ConnectionCheckClient = {
+    putObject: async (input) => {
+      putCalls.push(input)
+      if (options.putError) {
+        throw options.putError
+      }
+    },
+    getObject: async (input) => {
+      getCalls.push(input)
+      if (options.getError) {
+        throw options.getError
+      }
+      return options.getBody ?? probeBody
+    },
+    deleteObject: async (input) => {
+      deleteCalls.push(input)
+      if (options.deleteError) {
+        throw options.deleteError
+      }
+    },
+  }
+  const deps: R2ConnectionCheckCommandDeps = {
+    loadR2Config: () => config,
+    createS3Client: () => client,
+    createProbeKey: () => probeKey,
+    createProbeBody: () => probeBody,
+    ...overrides,
+  }
+  return { deps, putCalls, getCalls, deleteCalls }
+}
+
+describe('runR2ConnectionCheckCommand', () => {
+  test('uploads, reads, verifies, and deletes one unique temporary object', async () => {
+    const { deps, putCalls, getCalls, deleteCalls } = makeDeps()
+
+    const result = await runR2ConnectionCheckCommand([], {}, deps)
+
+    expect(putCalls).toEqual([
+      {
+        bucket: config.bucket,
+        key: probeKey,
+        body: probeBody,
+        ifNoneMatch: '*',
+      },
+    ])
+    expect(getCalls).toEqual([{ bucket: config.bucket, key: probeKey }])
+    expect(deleteCalls).toEqual([{ bucket: config.bucket, key: probeKey }])
+    expect(result).toEqual({
+      action: 'verified-and-deleted',
+      bucket: config.bucket,
+      key: probeKey,
+      bytes: probeBody.length,
+      sha256: createHash('sha256').update(probeBody).digest('hex'),
+    })
+  })
+
+  test('rejects arguments before loading configuration', async () => {
+    const loadR2Config = vi.fn(() => config)
+    const { deps } = makeDeps({}, { loadR2Config })
+
+    await expect(runR2ConnectionCheckCommand(['unexpected'], {}, deps)).rejects.toThrow(/Usage/)
+
+    expect(loadR2Config).not.toHaveBeenCalled()
+  })
+
+  test('deletes the temporary object when read-back fails', async () => {
+    const { deps, deleteCalls } = makeDeps({ getError: new Error('read failed') })
+
+    await expect(runR2ConnectionCheckCommand([], {}, deps)).rejects.toThrow(/read failed/)
+
+    expect(deleteCalls).toEqual([{ bucket: config.bucket, key: probeKey }])
+  })
+
+  test('deletes the temporary object when read-back bytes do not match', async () => {
+    const { deps, deleteCalls } = makeDeps({ getBody: Buffer.from('different bytes') })
+
+    await expect(runR2ConnectionCheckCommand([], {}, deps)).rejects.toThrow(/read-back mismatch/)
+
+    expect(deleteCalls).toEqual([{ bucket: config.bucket, key: probeKey }])
+  })
+
+  test('does not delete when upload fails before an object is created', async () => {
+    const { deps, getCalls, deleteCalls } = makeDeps({ putError: new Error('write denied') })
+
+    await expect(runR2ConnectionCheckCommand([], {}, deps)).rejects.toThrow(/write denied/)
+
+    expect(getCalls).toEqual([])
+    expect(deleteCalls).toEqual([])
+  })
+
+  test('fails when the verified temporary object cannot be deleted', async () => {
+    const { deps } = makeDeps({ deleteError: new Error('delete denied') })
+
+    await expect(runR2ConnectionCheckCommand([], {}, deps)).rejects.toThrow(
+      /temporary object ".*" cleanup failed: delete denied/,
+    )
+  })
+
+  test('redacts R2 credentials from operation and cleanup failures', async () => {
+    const { deps } = makeDeps({
+      getError: new Error(`read failed for ${config.accessKeyId}`),
+      deleteError: new Error(`delete failed for ${config.secretAccessKey}`),
+    })
+
+    let thrown: Error | undefined
+    try {
+      await runR2ConnectionCheckCommand([], {}, deps)
+    } catch (error) {
+      thrown = error as Error
+    }
+
+    expect(thrown?.message).toContain('<redacted>')
+    expect(thrown?.message).not.toContain(config.accessKeyId)
+    expect(thrown?.message).not.toContain(config.secretAccessKey)
+  })
+})
+
+describe('defaultR2ConnectionCheckCommandDeps', () => {
+  test('wires production R2 configuration and client factories', () => {
+    expect(defaultR2ConnectionCheckCommandDeps.loadR2Config).toBe(loadR2ObjectStoreConfigFromEnv)
+    expect(defaultR2ConnectionCheckCommandDeps.createS3Client).toBe(createS3ObjectClient)
+    expect(defaultR2ConnectionCheckCommandDeps.createProbeKey()).toMatch(
+      /^healthchecks\/poi-server\/r2-connection\/[0-9a-f-]{36}$/,
+    )
+    expect(defaultR2ConnectionCheckCommandDeps.createProbeBody()).toHaveLength(32)
+  })
+})
+
+test('r2ConnectionCheckCommandUsage documents the no-argument command', () => {
+  expect(r2ConnectionCheckCommandUsage).toBe('db:dumps:r2-check')
+})

--- a/tests/r2-object-store.test.ts
+++ b/tests/r2-object-store.test.ts
@@ -83,13 +83,13 @@ describe('createObjectStoreFromS3Client', () => {
     const store = createObjectStoreFromS3Client(client, 'dump-bucket')
     const body = Buffer.from('data object bytes')
 
-    const result = await store.putIfAbsent('months/2024-01/v1/x.jsonl.zst', body)
+    const result = await store.putIfAbsent('2024-01/x.jsonl.zst', body)
 
     expect(result).toEqual({ outcome: 'created' })
     expect(putCalls).toEqual([
       {
         bucket: 'dump-bucket',
-        key: 'months/2024-01/v1/x.jsonl.zst',
+        key: '2024-01/x.jsonl.zst',
         body,
         ifNoneMatch: '*',
       },
@@ -118,10 +118,10 @@ describe('createObjectStoreFromS3Client', () => {
     const { client, getCalls } = createFakeS3Client({ getBody: body })
     const store = createObjectStoreFromS3Client(client, 'dump-bucket')
 
-    const result = await store.getObject('months/2024-01/v1/manifest.json')
+    const result = await store.getObject('2024-01/manifest.json')
 
     expect(result).toEqual(body)
-    expect(getCalls).toEqual([{ bucket: 'dump-bucket', key: 'months/2024-01/v1/manifest.json' }])
+    expect(getCalls).toEqual([{ bucket: 'dump-bucket', key: '2024-01/manifest.json' }])
   })
 
   test('getObject translates a 404 into ObjectNotFoundError', async () => {


### PR DESCRIPTION
## Summary

- add `db:dumps:maintain`, a no-argument daily maintenance command that derives adjacent JST Dump Months, creates upcoming Observation partitions, publishes the previous closed month, and cleans every database-clock-eligible dump run
- keep partition creation, publication, cleanup discovery, and individual cleanup attempts independent so one failure does not suppress unrelated maintenance work
- add cleanup-eligible run discovery, shared CLI argument support, secret redaction, deterministic pool/client cleanup, and regression coverage
- add `run-monthly-dump-maintenance.sh` with non-blocking overlap protection, explicit skip/failure/success logs, and a configurable GNU `timeout`
- add `setup-monthly-dump-cron.sh`, an idempotent managed-crontab installer that preserves unrelated entries, validates configuration and marker integrity, prepares log/lock permissions, and schedules daily 00:30 JST retries by default
- document installation, configuration, verification, disabling, and operational behavior for both scripts
- document Cloudflare R2 bucket-scoped Object Read & Write S3 credential provisioning, runtime `.env` loading, and the read-back verification requirement
- add `db:dumps:r2-check`, which verifies the configured R2 lifecycle with a unique temporary Put/Get/byte-check/Delete probe and no PostgreSQL connection
- simplify immutable dump keys to root-level `<YYYY-MM>/` folders and enforce one canonical publication per Dump Month while retaining `schemaVersion` in the manifest
- add a report-data catalog covering all 18 current persisted datasets, including the nine current partitioned Observation Datasets and the retained Current State, Aggregate, Definition, and Item-improvement Fact datasets
- define `Observation Dataset` in the reporting glossary and clarify that partition counts follow the registry rather than representing a fixed number of months

## Validation

- `npm run test:unit` — 46 files, 629 tests
- `npm run type-check`
- `npm run lint -- --quiet`
- `bash -n ./setup-monthly-dump-cron.sh`
- `bash -n ./run-monthly-dump-maintenance.sh`
